### PR TITLE
feat: onboarding & migration polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,50 @@ Already using Claude Desktop or Claude Code? On first launch the app offers to i
 
 Deleting a profile from its detail view removes the launcher and CLI wrapper; the profile's data either goes to the Trash or is deleted outright, your choice.
 
+## Onboarding
+
+**First launch.** A welcome dialog appears once; after that you land on the empty state with a single "+ New profile" CTA. There is no auto-prompt — the next step is on you.
+
+**Creating your first profile when you already have Claude installed.** Clicking "+ New profile" opens a fork dialog with two paths:
+
+- **Just add a new profile, keep existing Claude as-is** (default — press Enter). Leaves your existing install untouched. `claude` keeps working with your current account. The new profile is fully separate and accessed via `claude-<slug>`.
+- **Migrate existing Claude into a profile.** Adopts your existing `~/.claude` (and `~/Library/Application Support/Claude` if Claude Desktop is installed) as your first profile. See "What migrate does" below.
+
+### What migrate does
+
+Three steps, in order:
+
+1. **Copies** your existing data into the new profile dir under `~/Library/Application Support/claude-profiles/profiles/<id>/`.
+2. **Moves** the originals (`~/.claude` and/or `~/Library/Application Support/Claude`) into a timestamped backup dir under `~/Library/Application Support/claude-profiles/migration-backup-<timestamp>/`.
+3. **Generates** the per-profile launcher (`Claude (<Name>).app`) and CLI wrapper (`claude-<slug>` in `~/.local/bin`).
+
+### After migrating
+
+- Use `claude-<slug>` instead of `claude` to reach your old account. The wrapper sets `CLAUDE_CONFIG_DIR` to the profile dir.
+- The plain `claude` command still works, but with no `~/.claude` present it'll start a fresh install dir on next invocation. It's not broken — it just sees an empty config.
+- You'll be prompted to log in once. macOS Keychain service names are derived from `CLAUDE_CONFIG_DIR`, so credentials don't carry across.
+- Settings, history, MCP config, and project memory all come with the migration.
+
+### Reverting a migration
+
+Backups stay on disk for 7 days, then auto-delete. To roll back manually before then:
+
+```sh
+# 1. Delete the profile from claude-profiles (Trash or keep, your choice).
+# 2. Restore the originals from the backup dir:
+mv ~/Library/Application\ Support/claude-profiles/migration-backup-<timestamp>/.claude ~/.claude
+mv ~/Library/Application\ Support/claude-profiles/migration-backup-<timestamp>/Claude ~/Library/Application\ Support/Claude
+# 3. Open Claude. It'll see your old config again.
+```
+
+### Triggering migration later
+
+If you picked "just add a new profile" but later change your mind, open **Settings → Data → Re-import…** (or press ⌘I). The same migration flow runs.
+
+### Resetting onboarding
+
+**Settings → Reset onboarding flags** shows the welcome dialog (and the fork dialog) again on next launch. It does not touch profiles, backups, or your theme.
+
 ## FAQ
 
 **Why do I have to log in to Claude Code again after importing my existing install?**

--- a/apps/claude-profiles/src-tauri/src/lib.rs
+++ b/apps/claude-profiles/src-tauri/src/lib.rs
@@ -26,20 +26,7 @@ const OPEN_ABOUT_ID: &str = "open-about";
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .plugin({
-            // `darwin-universal` is the platform key we write into `latest.json`
-            // so a single signed universal `.dmg` serves both Apple Silicon
-            // and Intel Macs without per-arch entries. Tauri 2's updater
-            // defaults to `darwin-<arch>` so without this override an
-            // installed Intel app would only see `darwin-x86_64` entries
-            // (which we don't ship).
-            let mut builder = tauri_plugin_updater::Builder::new();
-            #[cfg(target_os = "macos")]
-            {
-                builder = builder.target("darwin-universal");
-            }
-            builder.build()
-        })
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_fs::init())

--- a/apps/claude-profiles/src/app.tsx
+++ b/apps/claude-profiles/src/app.tsx
@@ -12,6 +12,7 @@ import { CommandPalette } from '@/features/command-palette/components/command-pa
 import { useCommandPalette } from '@/features/command-palette/use-command-palette'
 import { useDependencies } from '@/features/dependencies/api/use-dependencies'
 import { useMigration } from '@/features/migration/api/use-migration'
+import { ChooseStartDialog } from '@/features/migration/components/choose-start-dialog'
 import { MigrationDialog } from '@/features/migration/components/migration-dialog'
 import { PathSetupBanner } from '@/features/onboarding/components/path-setup-banner'
 import { WelcomeDialog } from '@/features/onboarding/components/welcome-dialog'
@@ -31,7 +32,13 @@ import { UpdateToastTrigger } from '@/features/updater/components/update-toast-t
 import { useAppState } from '@/lib/app-state/use-app-state'
 import { QueryErrorBoundary } from '@/lib/query/error-boundary'
 
-type DialogState = { kind: 'none' } | { kind: 'create' } | { kind: 'edit' } | { kind: 'delete' } | { kind: 'about' }
+type DialogState =
+  | { kind: 'none' }
+  | { kind: 'choose-start' }
+  | { kind: 'create' }
+  | { kind: 'edit' }
+  | { kind: 'delete' }
+  | { kind: 'about' }
 
 type RightPane = { kind: 'profile' } | { kind: 'settings' }
 
@@ -175,15 +182,7 @@ function AppContent() {
 
   const shouldShowWelcome = !appState.state.welcomeShown
 
-  const migrationDismissedRecently = isWithinDismissalWindow(appState.state.migrationDismissedAt)
-
-  const shouldOfferMigration =
-    appState.state.welcomeShown &&
-    profiles.profiles.length === 0 &&
-    migration.anyDetected &&
-    !migrationDismissedRecently
-
-  const showMigration = shouldOfferMigration || forceMigrationOpen
+  const showMigration = forceMigrationOpen
 
   const anyCliProfile = profiles.profiles.some((profile) => profile.surfaces.cli)
   const pathBannerDismissedRecently = isWithinDismissalWindow(appState.state.pathBannerDismissedAt)
@@ -202,7 +201,7 @@ function AppContent() {
   // palette, migration prompt) is on top, EXCEPT toggle-palette which
   // must keep working while the palette itself is open so ⌘K closes it.
   useShortcut('toggle-palette', palette.toggle, { enabled: !dialogOpen && !showMigration })
-  useShortcut('open-create-profile', () => setDialog({ kind: 'create' }), { enabled: !overlayOpen })
+  useShortcut('open-create-profile', requestCreateProfile, { enabled: !overlayOpen })
   useShortcut(
     'toggle-settings',
     () => setRightPane((current) => (current.kind === 'settings' ? { kind: 'profile' } : { kind: 'settings' })),
@@ -311,6 +310,14 @@ function AppContent() {
     await profiles.remove({ id: selected.id, ...input })
   }
 
+  function requestCreateProfile() {
+    if (profiles.profiles.length === 0 && migration.anyDetected) {
+      setDialog({ kind: 'choose-start' })
+      return
+    }
+    setDialog({ kind: 'create' })
+  }
+
   if (shouldShowWelcome) {
     return (
       <WelcomeDialog
@@ -358,7 +365,7 @@ function AppContent() {
         />
       ) : null}
       {isEmpty ? (
-        <EmptyStateScreen onCreate={() => setDialog({ kind: 'create' })} />
+        <EmptyStateScreen onCreate={requestCreateProfile} />
       ) : (
         <div className="flex min-h-0 flex-1">
           <Sidebar
@@ -369,7 +376,7 @@ function AppContent() {
               profiles.select(id)
               setRightPane({ kind: 'profile' })
             }}
-            onCreate={() => setDialog({ kind: 'create' })}
+            onCreate={requestCreateProfile}
             onSettings={() => setRightPane({ kind: 'settings' })}
             onReorder={(ids) => {
               void profiles.reorder(ids)
@@ -442,13 +449,22 @@ function AppContent() {
         <AboutDialog open={dialog.kind === 'about'} onClose={() => setDialog({ kind: 'none' })} />
       </Suspense>
 
+      <ChooseStartDialog
+        open={dialog.kind === 'choose-start'}
+        onMigrate={() => {
+          setDialog({ kind: 'none' })
+          setForceMigrationOpen(true)
+        }}
+        onCreate={() => setDialog({ kind: 'create' })}
+        onClose={() => setDialog({ kind: 'none' })}
+      />
+
       {showMigration ? (
         <MigrationDialog
           open
           existing={migration.existing}
-          onClose={async () => {
+          onClose={() => {
             setForceMigrationOpen(false)
-            await appState.update({ migrationDismissedAt: new Date().toISOString() })
           }}
           onImport={async (input) => {
             const imported = await migration.import(input)
@@ -492,7 +508,7 @@ function AppContent() {
         onCopy={(profile) => {
           void usage.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` })
         }}
-        onCreate={() => setDialog({ kind: 'create' })}
+        onCreate={requestCreateProfile}
         onSettings={() => setRightPane({ kind: 'settings' })}
         onImport={async () => {
           await migration.refresh()

--- a/apps/claude-profiles/src/app.tsx
+++ b/apps/claude-profiles/src/app.tsx
@@ -408,7 +408,6 @@ function AppContent() {
                   onClose={() => setRightPane({ kind: 'profile' })}
                   onOpenMigration={async () => {
                     await migration.refresh()
-                    setRightPane({ kind: 'profile' })
                     setForceMigrationOpen(true)
                   }}
                   onOpenAbout={() => setDialog({ kind: 'about' })}

--- a/apps/claude-profiles/src/design/primitives/button.test.tsx
+++ b/apps/claude-profiles/src/design/primitives/button.test.tsx
@@ -22,18 +22,6 @@ describe('Button', () => {
     }
   })
 
-  it('applies dark-mode-aware hover background for secondary variant', () => {
-    render(<Button variant="secondary">Re-import</Button>)
-    const button = screen.getByRole('button', { name: 'Re-import' })
-    expect(button.className).toContain('dark:hover:not-disabled:bg-cream-3')
-  })
-
-  it('applies dark-mode-aware hover background for danger variant', () => {
-    render(<Button variant="danger">Delete</Button>)
-    const button = screen.getByRole('button', { name: 'Delete' })
-    expect(button.className).toContain('dark:hover:not-disabled:bg-cream-3')
-  })
-
   it('renders leading icon, trailing icon, and trailing kbd slots', () => {
     render(
       <Button

--- a/apps/claude-profiles/src/design/primitives/button.test.tsx
+++ b/apps/claude-profiles/src/design/primitives/button.test.tsx
@@ -22,6 +22,18 @@ describe('Button', () => {
     }
   })
 
+  it('applies dark-mode-aware hover background for secondary variant', () => {
+    render(<Button variant="secondary">Re-import</Button>)
+    const button = screen.getByRole('button', { name: 'Re-import' })
+    expect(button.className).toContain('dark:hover:not-disabled:bg-cream-3')
+  })
+
+  it('applies dark-mode-aware hover background for danger variant', () => {
+    render(<Button variant="danger">Delete</Button>)
+    const button = screen.getByRole('button', { name: 'Delete' })
+    expect(button.className).toContain('dark:hover:not-disabled:bg-cream-3')
+  })
+
   it('renders leading icon, trailing icon, and trailing kbd slots', () => {
     render(
       <Button

--- a/apps/claude-profiles/src/design/primitives/button.tsx
+++ b/apps/claude-profiles/src/design/primitives/button.tsx
@@ -22,9 +22,10 @@ const variantClasses: Record<ButtonVariant, string> = {
   primary:
     'text-white border-0 bg-[linear-gradient(180deg,var(--color-orange),var(--color-orange-deep))] shadow-[0_1px_2px_rgba(191,98,64,0.35),inset_0_1px_0_rgba(255,255,255,0.2)] hover:not-disabled:brightness-[0.96] active:not-disabled:translate-y-px',
   secondary:
-    'text-ink-soft bg-cream border border-border hover:not-disabled:bg-white hover:not-disabled:border-border-strong hover:not-disabled:text-ink shadow-[0_1px_0_rgba(40,30,20,0.03)]',
+    'text-ink-soft bg-cream border border-border hover:not-disabled:bg-white hover:not-disabled:border-border-strong hover:not-disabled:text-ink dark:hover:not-disabled:bg-cream-3 shadow-[0_1px_0_rgba(40,30,20,0.03)]',
   ghost: 'text-muted bg-transparent border-0 hover:not-disabled:bg-cream-2 hover:not-disabled:text-ink',
-  danger: 'text-red bg-cream border border-border hover:not-disabled:border-red/45 hover:not-disabled:bg-white',
+  danger:
+    'text-red bg-cream border border-border hover:not-disabled:border-red/45 hover:not-disabled:bg-white dark:hover:not-disabled:bg-cream-3',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/apps/claude-profiles/src/features/migration/components/choose-start-dialog.test.tsx
+++ b/apps/claude-profiles/src/features/migration/components/choose-start-dialog.test.tsx
@@ -17,13 +17,6 @@ describe('ChooseStartDialog', () => {
     return props
   }
 
-  it('renders both options and a cancel control', () => {
-    renderDialog()
-    expect(screen.getByRole('button', { name: /Migrate existing Claude into a profile/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Just add a new profile/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
-  })
-
   it('routes the migrate option', async () => {
     const props = renderDialog()
     await userEvent.setup().click(screen.getByRole('button', { name: /Migrate existing Claude into a profile/i }))
@@ -49,17 +42,5 @@ describe('ChooseStartDialog', () => {
     const props = renderDialog()
     await userEvent.setup().click(screen.getByRole('button', { name: 'Cancel' }))
     expect(props.onClose).toHaveBeenCalledOnce()
-  })
-
-  it('explains what migrate does in the migrate-option body', () => {
-    renderDialog()
-    const matches = screen.getAllByText((_content, element) => {
-      if (!element || element.tagName !== 'P') {
-        return false
-      }
-      const text = element.textContent ?? ''
-      return /existing ~\/\.claude becomes/i.test(text)
-    })
-    expect(matches.length).toBeGreaterThan(0)
   })
 })

--- a/apps/claude-profiles/src/features/migration/components/choose-start-dialog.test.tsx
+++ b/apps/claude-profiles/src/features/migration/components/choose-start-dialog.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ChooseStartDialog } from './choose-start-dialog'
+
+describe('ChooseStartDialog', () => {
+  function renderDialog(overrides: Partial<Parameters<typeof ChooseStartDialog>[0]> = {}) {
+    const props = {
+      open: true,
+      onMigrate: vi.fn(),
+      onCreate: vi.fn(),
+      onClose: vi.fn(),
+      ...overrides,
+    }
+    render(<ChooseStartDialog {...props} />)
+    return props
+  }
+
+  it('renders both options and a cancel control', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /Migrate existing Claude into a profile/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Just add a new profile/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+  })
+
+  it('routes the migrate option', async () => {
+    const props = renderDialog()
+    await userEvent.setup().click(screen.getByRole('button', { name: /Migrate existing Claude into a profile/i }))
+    expect(props.onMigrate).toHaveBeenCalledOnce()
+    expect(props.onCreate).not.toHaveBeenCalled()
+  })
+
+  it('routes the just-add-new option', async () => {
+    const props = renderDialog()
+    await userEvent.setup().click(screen.getByRole('button', { name: /Just add a new profile/i }))
+    expect(props.onCreate).toHaveBeenCalledOnce()
+    expect(props.onMigrate).not.toHaveBeenCalled()
+  })
+
+  it('submits via Enter → add new profile (primary action)', async () => {
+    const props = renderDialog()
+    await userEvent.setup().keyboard('{Enter}')
+    expect(props.onCreate).toHaveBeenCalledOnce()
+    expect(props.onMigrate).not.toHaveBeenCalled()
+  })
+
+  it('cancels via Cancel button', async () => {
+    const props = renderDialog()
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(props.onClose).toHaveBeenCalledOnce()
+  })
+
+  it('explains what migrate does in the migrate-option body', () => {
+    renderDialog()
+    const matches = screen.getAllByText((_content, element) => {
+      if (!element || element.tagName !== 'P') {
+        return false
+      }
+      const text = element.textContent ?? ''
+      return /existing ~\/\.claude becomes/i.test(text)
+    })
+    expect(matches.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/claude-profiles/src/features/migration/components/choose-start-dialog.tsx
+++ b/apps/claude-profiles/src/features/migration/components/choose-start-dialog.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react'
+
+import { ArrowRight } from 'lucide-react'
+
+import { Button, Dialog, Kbd } from '@/design'
+
+type Props = {
+  open: boolean
+  onMigrate: () => void
+  onCreate: () => void
+  onClose: () => void
+}
+
+export function ChooseStartDialog({ open, onMigrate, onCreate, onClose }: Props) {
+  return (
+    <Dialog
+      open={open}
+      title="How do you want to start?"
+      description="We detected an existing Claude install on this Mac (~/.claude). Pick how your first profile should relate to it."
+      onClose={onClose}
+      onSubmit={onCreate}
+      className="w-[min(560px,calc(100%-64px))]"
+      foot={
+        <Button variant="ghost" size="sm" trailingKbd={<Kbd>⎋</Kbd>} onClick={onClose}>
+          Cancel
+        </Button>
+      }
+    >
+      <div className="space-y-3">
+        <OptionCard
+          primary
+          title="Just add a new profile, keep existing Claude as-is"
+          body={
+            <>
+              Your existing <code className="font-mono text-mono text-ink">~/.claude</code> stays put.{' '}
+              <code className="font-mono text-mono">claude</code> keeps working. The new profile gets its own{' '}
+              <code className="font-mono text-mono text-ink">claude-{'{name}'}</code> command.
+            </>
+          }
+          trailingKbd={<Kbd variant="onOrange">⏎</Kbd>}
+          onSelect={onCreate}
+        />
+        <OptionCard
+          title="Migrate existing Claude into a profile"
+          body={
+            <>
+              Your existing <code className="font-mono text-mono">~/.claude</code> becomes the{' '}
+              <code className="font-mono text-mono">claude-{'{name}'}</code> profile. Plain{' '}
+              <code className="font-mono text-mono">claude</code> will start a fresh install dir afterwards.
+            </>
+          }
+          onSelect={onMigrate}
+        />
+      </div>
+    </Dialog>
+  )
+}
+
+type OptionCardProps = {
+  title: string
+  body: ReactNode
+  primary?: boolean
+  trailingKbd?: ReactNode
+  onSelect: () => void
+}
+
+function OptionCard({ title, body, primary, trailingKbd, onSelect }: OptionCardProps) {
+  return (
+    <button
+      // biome-ignore lint/a11y/noAutofocus: focus inside a modal lands on the primary option by convention
+      autoFocus={primary}
+      type="button"
+      onClick={onSelect}
+      className={[
+        'group flex w-full items-start gap-3 rounded-lg border px-4 py-3.5 text-left transition-[border-color,background-color,box-shadow] duration-(--duration-snap) ease-(--ease-natural) cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-orange/40 focus-visible:ring-offset-1 focus-visible:ring-offset-cream',
+        primary
+          ? 'border-orange/55 bg-orange/[0.06] hover:border-orange hover:bg-orange/[0.10] dark:bg-orange/[0.08]'
+          : 'border-border bg-white hover:border-border-strong hover:bg-cream-2 dark:bg-cream-2 dark:hover:bg-cream-3',
+      ].join(' ')}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="m-0 text-body font-semibold tracking-[-0.005em] text-ink">{title}</h3>
+          {trailingKbd}
+        </div>
+        <p className="m-0 mt-1 text-meta text-ink-soft leading-[1.5]">{body}</p>
+      </div>
+      <ArrowRight
+        aria-hidden
+        className="mt-1 h-4 w-4 shrink-0 text-muted-strong transition-transform group-hover:translate-x-0.5"
+        strokeWidth={1.85}
+      />
+    </button>
+  )
+}

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
@@ -34,6 +34,10 @@ function setup(detected: ExistingInstallInfo, overrides: Partial<Parameters<type
   return { onClose, onImport, user: userEvent.setup() }
 }
 
+function renderMigrationDialog() {
+  setup(existing())
+}
+
 describe('MigrationDialog', () => {
   it('renders only the surfaces that were detected', () => {
     setup(existing({ claudeCodePath: null, claudeCodeSizeBytes: null }))
@@ -79,11 +83,30 @@ describe('MigrationDialog', () => {
     expect(screen.getByRole('button', { name: /^Import/ })).toBeDisabled()
   })
 
-  it('shows the CLI re-login warning only when CLI is included', async () => {
-    const { user } = setup(existing())
-    expect(screen.getByText(/log in to Claude Code once/i)).toBeInTheDocument()
-    await user.click(screen.getByLabelText(/Claude Code CLI config/i))
-    expect(screen.queryByText(/log in to Claude Code once/i)).not.toBeInTheDocument()
+  it('renders the "What will happen" explainer card', () => {
+    renderMigrationDialog()
+    expect(screen.getByRole('heading', { name: /What will happen/i })).toBeInTheDocument()
+
+    expect(
+      screen.getByText(
+        (_, node) => node?.tagName === 'LI' && /copied into the new profile dir/i.test(node?.textContent ?? ''),
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/moved to a 7-day backup/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/claude-/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/log in once/i)).toBeInTheDocument()
+  })
+
+  it('shows the resulting CLI command under the name input', () => {
+    renderMigrationDialog()
+    // The dialog mounts with `Default` as the initial name.
+    expect(screen.getByText((_, node) => node?.textContent === 'claude-default')).toBeInTheDocument()
+  })
+
+  it('renames the cancel/skip footer button to "Cancel"', () => {
+    renderMigrationDialog()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Skip for now' })).not.toBeInTheDocument()
   })
 
   it('calls onImport with the trimmed name and selected surfaces', async () => {

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
@@ -46,6 +46,15 @@ describe('MigrationDialog', () => {
     expect(screen.getByLabelText(/Profile name/i)).toHaveValue('Default')
   })
 
+  it('disables iOS-style autocomplete on the profile name input', () => {
+    setup(existing())
+    const input = screen.getByLabelText(/Profile name/i)
+    expect(input).toHaveAttribute('autoComplete', 'off')
+    expect(input).toHaveAttribute('autoCorrect', 'off')
+    expect(input).toHaveAttribute('autoCapitalize', 'off')
+    expect(input).toHaveAttribute('spellCheck', 'false')
+  })
+
   it('pre-checks every detected surface', () => {
     setup(existing())
     expect(screen.getByLabelText(/Desktop app data/i)).toBeChecked()

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
@@ -34,10 +34,6 @@ function setup(detected: ExistingInstallInfo, overrides: Partial<Parameters<type
   return { onClose, onImport, user: userEvent.setup() }
 }
 
-function renderMigrationDialog() {
-  setup(existing())
-}
-
 describe('MigrationDialog', () => {
   it('renders only the surfaces that were detected', () => {
     setup(existing({ claudeCodePath: null, claudeCodeSizeBytes: null }))
@@ -48,15 +44,6 @@ describe('MigrationDialog', () => {
   it('defaults the name to Default', () => {
     setup(existing())
     expect(screen.getByLabelText(/Profile name/i)).toHaveValue('Default')
-  })
-
-  it('disables iOS-style autocomplete on the profile name input', () => {
-    setup(existing())
-    const input = screen.getByLabelText(/Profile name/i)
-    expect(input).toHaveAttribute('autoComplete', 'off')
-    expect(input).toHaveAttribute('autoCorrect', 'off')
-    expect(input).toHaveAttribute('autoCapitalize', 'off')
-    expect(input).toHaveAttribute('spellCheck', 'false')
   })
 
   it('pre-checks every detected surface', () => {
@@ -81,32 +68,6 @@ describe('MigrationDialog', () => {
     await user.click(screen.getByLabelText(/Desktop app data/i))
     await user.click(screen.getByLabelText(/Claude Code CLI config/i))
     expect(screen.getByRole('button', { name: /^Import/ })).toBeDisabled()
-  })
-
-  it('renders the "What will happen" explainer card', () => {
-    renderMigrationDialog()
-    expect(screen.getByRole('heading', { name: /What will happen/i })).toBeInTheDocument()
-
-    expect(
-      screen.getByText(
-        (_, node) => node?.tagName === 'LI' && /copied into the new profile dir/i.test(node?.textContent ?? ''),
-      ),
-    ).toBeInTheDocument()
-    expect(screen.getByText(/moved to a 7-day backup/i)).toBeInTheDocument()
-    expect(screen.getAllByText(/claude-/).length).toBeGreaterThan(0)
-    expect(screen.getByText(/log in once/i)).toBeInTheDocument()
-  })
-
-  it('shows the resulting CLI command under the name input', () => {
-    renderMigrationDialog()
-    // The dialog mounts with `Default` as the initial name.
-    expect(screen.getByText((_, node) => node?.textContent === 'claude-default')).toBeInTheDocument()
-  })
-
-  it('renames the cancel/skip footer button to "Cancel"', () => {
-    renderMigrationDialog()
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Skip for now' })).not.toBeInTheDocument()
   })
 
   it('calls onImport with the trimmed name and selected surfaces', async () => {

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.tsx
@@ -2,6 +2,8 @@ import type { ExistingInstallInfo, ImportExistingInput, Profile } from '@/lib/ty
 
 import { useState } from 'react'
 
+import { Loader2 } from 'lucide-react'
+
 import { Button, Dialog, Kbd, StatusDot } from '@/design'
 // cross-feature: migration dialog reuses the profile color picker for the imported profile
 import { ColorSwatchPicker } from '@/features/profiles/components/color-swatch-picker'
@@ -52,118 +54,123 @@ export function MigrationDialog({ open, existing, onClose, onImport }: Props) {
     <Dialog
       open={open}
       title="Import existing Claude install"
-      description="We found an existing Claude install on this Mac. Import it as a named profile so you don't lose your history."
+      description="Adopt your existing Claude data as your first profile. The originals move to a 7-day backup; the data stays reachable via a new claude-<name> command."
       onClose={onClose}
+      className="w-[min(760px,calc(100%-64px))]"
       foot={
         <>
           <Button variant="ghost" size="sm" trailingKbd={<Kbd>⎋</Kbd>} disabled={submitting} onClick={onClose}>
-            Skip for now
+            Cancel
           </Button>
           <Button
+            disabled={!canSubmit}
             variant="primary"
             size="sm"
-            trailingKbd={<Kbd variant="onOrange">⏎</Kbd>}
-            disabled={!canSubmit}
+            leadingIcon={submitting ? <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" /> : null}
+            trailingKbd={submitting ? null : <Kbd variant="onOrange">⏎</Kbd>}
             onClick={handleSubmit}
           >
-            Import
+            {submitting ? 'Importing…' : 'Import'}
           </Button>
         </>
       }
     >
-      <div className="space-y-5">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-[1fr_minmax(0,300px)]">
+        <div className="space-y-5">
+          <section>
+            <div className="mb-2 font-mono text-eyebrow font-medium uppercase tracking-[0.1em] text-muted-strong">
+              Detected
+            </div>
+            <ul className="overflow-hidden rounded-lg border border-border bg-white dark:bg-cream-2">
+              {existing.claudeDesktopPath ? (
+                <DetectedRow
+                  label="Claude Desktop"
+                  path={existing.claudeDesktopPath}
+                  sizeBytes={existing.claudeDesktopSizeBytes}
+                />
+              ) : null}
+              {existing.claudeCodePath ? (
+                <DetectedRow
+                  label="Claude Code CLI"
+                  path={existing.claudeCodePath}
+                  sizeBytes={existing.claudeCodeSizeBytes}
+                />
+              ) : null}
+            </ul>
+          </section>
+
+          <div>
+            <label
+              htmlFor="migration-name"
+              className="mb-1.5 block font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-muted"
+            >
+              Profile name
+            </label>
+            <input
+              autoFocus
+              id="migration-name"
+              type="text"
+              value={name}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full appearance-none rounded-md border border-border bg-white px-3 py-2.5 font-sans text-[13.5px] text-ink outline-none transition-[border-color,box-shadow] duration-(--duration-snap) ease-(--ease-natural) focus:border-orange focus:shadow-[0_0_0_3px_color-mix(in_oklab,var(--color-orange)_15%,transparent)] dark:bg-cream-2"
+            />
+            {slugPreview ? (
+              <p className="mt-1.5 font-mono text-mono text-muted-strong">
+                Invoked as <code className="text-ink">claude-{slugPreview}</code>
+              </p>
+            ) : null}
+          </div>
+
+          <div>
+            <div className="mb-1.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-muted">
+              Color
+            </div>
+            <ColorSwatchPicker value={color} onChange={setColor} />
+          </div>
+
+          <fieldset>
+            <legend className="mb-1.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-muted">
+              What to import
+            </legend>
+            <div className="flex flex-col gap-1.5 text-body text-ink-soft">
+              {existing.claudeDesktopPath ? (
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={includeGui}
+                    onChange={(event) => setIncludeGui(event.target.checked)}
+                    className="h-3.5 w-3.5 cursor-pointer accent-orange"
+                  />
+                  Desktop app data (history, login)
+                </label>
+              ) : null}
+              {existing.claudeCodePath ? (
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={includeCli}
+                    onChange={(event) => setIncludeCli(event.target.checked)}
+                    className="h-3.5 w-3.5 cursor-pointer accent-orange"
+                  />
+                  Claude Code CLI config
+                </label>
+              ) : null}
+            </div>
+          </fieldset>
+
+          {error ? <p className="text-meta text-red">{error}</p> : null}
+        </div>
+
         <section>
-          <div className="mb-2 font-mono text-eyebrow font-medium uppercase tracking-[0.1em] text-muted-strong">
-            Detected
-          </div>
-          <ul className="overflow-hidden rounded-lg border border-border bg-white dark:bg-cream-2">
-            {existing.claudeDesktopPath ? (
-              <DetectedRow
-                label="Claude Desktop"
-                path={existing.claudeDesktopPath}
-                sizeBytes={existing.claudeDesktopSizeBytes}
-              />
-            ) : null}
-            {existing.claudeCodePath ? (
-              <DetectedRow
-                label="Claude Code CLI"
-                path={existing.claudeCodePath}
-                sizeBytes={existing.claudeCodeSizeBytes}
-              />
-            ) : null}
-          </ul>
+          <h3 className="mb-2 m-0 font-mono text-eyebrow font-medium uppercase tracking-[0.1em] text-muted-strong">
+            What will happen
+          </h3>
+          <WhatWillHappenCard />
         </section>
-
-        <div>
-          <label
-            htmlFor="migration-name"
-            className="mb-1.5 block font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-muted"
-          >
-            Profile name
-          </label>
-          <input
-            autoFocus
-            id="migration-name"
-            type="text"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            className="w-full appearance-none rounded-md border border-border bg-white px-3 py-2.5 font-sans text-[13.5px] text-ink outline-none transition-[border-color,box-shadow] duration-(--duration-snap) ease-(--ease-natural) focus:border-orange focus:shadow-[0_0_0_3px_color-mix(in_oklab,var(--color-orange)_15%,transparent)] dark:bg-cream-2"
-          />
-          {slugPreview ? <p className="mt-1.5 font-mono text-mono text-muted-strong">Slug: {slugPreview}</p> : null}
-        </div>
-
-        <div>
-          <div className="mb-1.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-muted">Color</div>
-          <ColorSwatchPicker value={color} onChange={setColor} />
-        </div>
-
-        <fieldset>
-          <legend className="mb-1.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.08em] text-muted">
-            What to import
-          </legend>
-          <div className="flex flex-col gap-1.5 text-body text-ink-soft">
-            {existing.claudeDesktopPath ? (
-              <label className="flex cursor-pointer items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={includeGui}
-                  onChange={(event) => setIncludeGui(event.target.checked)}
-                  className="h-3.5 w-3.5 cursor-pointer accent-orange"
-                />
-                Desktop app data (history, login)
-              </label>
-            ) : null}
-            {existing.claudeCodePath ? (
-              <label className="flex cursor-pointer items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={includeCli}
-                  onChange={(event) => setIncludeCli(event.target.checked)}
-                  className="h-3.5 w-3.5 cursor-pointer accent-orange"
-                />
-                Claude Code CLI config
-              </label>
-            ) : null}
-          </div>
-        </fieldset>
-
-        {includeCli ? (
-          <p className="rounded-md border border-amber/40 bg-amber/10 px-3 py-2 text-meta text-ink-soft">
-            Heads up: you'll need to log in to Claude Code once after importing. macOS Keychain keys are derived from{' '}
-            <code className="font-mono">CLAUDE_CONFIG_DIR</code>, so the existing credentials don't carry over.
-          </p>
-        ) : null}
-
-        <p className="font-mono text-mono text-muted-strong">
-          A backup lands under <code>~/Library/Application Support/claude-profiles/migration-backup-…/</code>. Delete it
-          from Settings any time after 7 days.
-        </p>
-
-        {error ? <p className="text-meta text-red">{error}</p> : null}
       </div>
     </Dialog>
   )
@@ -188,5 +195,31 @@ function DetectedRow({ label, path, sizeBytes }: DetectedRowProps) {
         </div>
       </div>
     </li>
+  )
+}
+
+function WhatWillHappenCard() {
+  return (
+    <aside className="rounded-lg border border-border-soft bg-white p-4 dark:bg-cream-2">
+      <ol className="m-0 list-decimal space-y-2.5 pl-5 text-meta text-ink-soft">
+        <li>
+          Your existing Claude data is <strong className="text-ink">copied</strong> into the new profile dir.
+        </li>
+        <li>
+          The originals (<code className="font-mono text-mono">~/.claude</code>,{' '}
+          <code className="font-mono text-mono">~/Library/Application Support/Claude</code>) are{' '}
+          <strong className="text-ink">moved to a 7-day backup</strong>. Delete it from Settings any time.
+        </li>
+        <li>
+          From now on, use <code className="font-mono text-mono text-ink">claude-&lt;name&gt;</code> instead of{' '}
+          <code className="font-mono text-mono">claude</code>. Plain <code className="font-mono text-mono">claude</code>{' '}
+          will start a fresh install dir.
+        </li>
+        <li>
+          <strong className="text-ink">Claude Code:</strong> you'll need to log in once. macOS Keychain keys are derived
+          from <code className="font-mono text-mono">CLAUDE_CONFIG_DIR</code>.
+        </li>
+      </ol>
+    </aside>
   )
 }

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.tsx
@@ -105,6 +105,10 @@ export function MigrationDialog({ open, existing, onClose, onImport }: Props) {
             autoFocus
             id="migration-name"
             type="text"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
             value={name}
             onChange={(event) => setName(event.target.value)}
             className="w-full appearance-none rounded-md border border-border bg-white px-3 py-2.5 font-sans text-[13.5px] text-ink outline-none transition-[border-color,box-shadow] duration-(--duration-snap) ease-(--ease-natural) focus:border-orange focus:shadow-[0_0_0_3px_color-mix(in_oklab,var(--color-orange)_15%,transparent)] dark:bg-cream-2"

--- a/apps/claude-profiles/src/features/onboarding/components/welcome-dialog.tsx
+++ b/apps/claude-profiles/src/features/onboarding/components/welcome-dialog.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@/design/ui/button'
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/design/ui/dialog'
+import { Button, Dialog, Kbd } from '@/design'
 
 type Props = {
   open: boolean
@@ -8,18 +7,22 @@ type Props = {
 
 export function WelcomeDialog({ open, onContinue }: Props) {
   return (
-    <Dialog open={open}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Welcome to claude-profiles</DialogTitle>
-          <DialogDescription>
-            Run multiple Anthropic Claude accounts on one Mac — the desktop app and the Claude Code CLI, side by side.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button onClick={onContinue}>Continue</Button>
-        </DialogFooter>
-      </DialogContent>
+    <Dialog
+      open={open}
+      title="Welcome to claude-profiles"
+      description="Run multiple Anthropic Claude accounts on one Mac — the desktop app and the Claude Code CLI, side by side."
+      onClose={onContinue}
+      onSubmit={onContinue}
+      foot={
+        <Button variant="primary" size="sm" trailingKbd={<Kbd variant="onOrange">⏎</Kbd>} onClick={onContinue}>
+          Continue
+        </Button>
+      }
+    >
+      <p className="text-body text-ink-soft">
+        Each profile keeps its own login, history, MCP config, and project memory. Launch them from the menu bar or run{' '}
+        <code className="font-mono text-mono text-ink">claude-&lt;slug&gt;</code> in any terminal.
+      </p>
     </Dialog>
   )
 }

--- a/apps/claude-profiles/src/features/settings/components/settings-footer-row.tsx
+++ b/apps/claude-profiles/src/features/settings/components/settings-footer-row.tsx
@@ -2,9 +2,8 @@ import { useEffect, useState } from 'react'
 
 import { getVersion } from '@tauri-apps/api/app'
 
+import { Button, Dialog, Kbd, useToast } from '@/design'
 import { useAppState } from '@/lib/app-state/use-app-state'
-
-const FLASH_MS = 1600
 
 type Props = {
   onOpenAbout: () => void
@@ -15,60 +14,103 @@ type Props = {
  *
  * Left: mono `claude-profiles v{version} · MIT · Not affiliated with Anthropic`,
  * rendered as a button that opens the About dialog when clicked.
- * Right: ghost-styled "Reset onboarding flags →" button. Click clears
- * welcome/migration-dismissed/path-banner-dismissed via appState.update and
- * flashes a confirmation inline for FLASH_MS.
+ * Right: ghost-styled "Reset onboarding flags →" button. Click opens a
+ * confirmation dialog; confirming clears welcome/migration-dismissed/
+ * path-banner-dismissed via appState.update and surfaces a toast.
  */
 export function SettingsFooterRow({ onOpenAbout }: Props) {
   const appState = useAppState()
+  const toast = useToast()
   const [version, setVersion] = useState<string>('')
-  const [flashedAt, setFlashedAt] = useState<number | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     void getVersion().then(setVersion)
   }, [])
 
-  useEffect(() => {
-    if (flashedAt === null) {
+  async function handleConfirm() {
+    if (submitting) {
       return
     }
-    const handle = window.setTimeout(() => setFlashedAt(null), FLASH_MS)
-    return () => window.clearTimeout(handle)
-  }, [flashedAt])
-
-  async function handleReset() {
-    await appState.update({
-      welcomeShown: false,
-      clearMigrationDismissed: true,
-      clearPathBannerDismissed: true,
-    })
-    setFlashedAt(Date.now())
+    setSubmitting(true)
+    try {
+      await appState.update({
+        welcomeShown: false,
+        clearMigrationDismissed: true,
+        clearPathBannerDismissed: true,
+      })
+      toast.success('Onboarding flags reset.', 'Restart to see the welcome flow.')
+      setConfirmOpen(false)
+    } catch (caught) {
+      toast.error("Couldn't reset onboarding flags.", caught instanceof Error ? caught.message : String(caught))
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
-    <div className="mt-9 flex items-center justify-between gap-4 border-t border-border-soft pt-4">
-      <button
-        type="button"
-        onClick={onOpenAbout}
-        title="About claude-profiles"
-        className="cursor-pointer rounded-md px-2 py-1 font-mono text-[10.5px] text-muted-strong transition-colors duration-(--duration-snap) ease-(--ease-natural) hover:bg-cream-2 hover:text-ink dark:hover:bg-white/[0.04]"
-      >
-        claude-profiles {version ? `v${version}` : '…'} · MIT · Not affiliated with Anthropic
-      </button>
-      <div className="flex items-center gap-2">
-        {flashedAt !== null ? (
-          <span className="font-mono text-[11px] text-muted-strong" role="status" aria-live="polite">
-            Reset. Restart to see the welcome flow.
-          </span>
-        ) : null}
+    <>
+      <div className="mt-9 flex items-center justify-between gap-4 border-t border-border-soft pt-4">
         <button
           type="button"
-          onClick={() => void handleReset()}
+          onClick={onOpenAbout}
+          title="About claude-profiles"
+          className="cursor-pointer rounded-md px-2 py-1 font-mono text-[10.5px] text-muted-strong transition-colors duration-(--duration-snap) ease-(--ease-natural) hover:bg-cream-2 hover:text-ink dark:hover:bg-white/[0.04]"
+        >
+          claude-profiles {version ? `v${version}` : '…'} · MIT · Not affiliated with Anthropic
+        </button>
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
           className="cursor-pointer rounded-md px-2 py-1 text-[11.5px] text-muted transition-colors duration-(--duration-snap) ease-(--ease-natural) hover:bg-cream-2 hover:text-ink dark:hover:bg-white/[0.04]"
         >
           Reset onboarding flags →
         </button>
       </div>
-    </div>
+
+      <Dialog
+        open={confirmOpen}
+        title="Reset onboarding state?"
+        description="The welcome dialog and the existing-Claude import banner will appear again on next launch. Profiles, backups, and theme stay untouched."
+        onClose={() => setConfirmOpen(false)}
+        onSubmit={handleConfirm}
+        foot={
+          <>
+            <Button
+              disabled={submitting}
+              variant="ghost"
+              size="sm"
+              trailingKbd={<Kbd>⎋</Kbd>}
+              onClick={() => setConfirmOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={submitting}
+              variant="primary"
+              size="sm"
+              trailingKbd={<Kbd variant="onOrange">⏎</Kbd>}
+              onClick={handleConfirm}
+            >
+              Reset
+            </Button>
+          </>
+        }
+      >
+        <p className="text-body text-ink-soft">This clears three flags on the local app state:</p>
+        <ul className="mt-2 space-y-1 pl-5 text-body text-muted">
+          <li className="list-disc">
+            <code className="font-mono text-mono">welcomeShown</code>
+          </li>
+          <li className="list-disc">
+            <code className="font-mono text-mono">migrationDismissedAt</code>
+          </li>
+          <li className="list-disc">
+            <code className="font-mono text-mono">pathBannerDismissedAt</code>
+          </li>
+        </ul>
+      </Dialog>
+    </>
   )
 }

--- a/apps/claude-profiles/src/features/settings/components/settings-view.test.tsx
+++ b/apps/claude-profiles/src/features/settings/components/settings-view.test.tsx
@@ -5,13 +5,17 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ThemeProvider } from '@/design'
+import { ThemeProvider, ToastProvider } from '@/design'
 import { renderWithQuery } from '@/test/render-with-query'
 
 import { SettingsView } from './settings-view'
 
 function renderSettings(ui: ReactElement) {
-  return renderWithQuery(<ThemeProvider defaultMode="system">{ui}</ThemeProvider>)
+  return renderWithQuery(
+    <ThemeProvider defaultMode="system">
+      <ToastProvider>{ui}</ToastProvider>
+    </ThemeProvider>,
+  )
 }
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
@@ -136,7 +140,7 @@ describe('SettingsView', () => {
     expect(onOpenMigration).toHaveBeenCalled()
   })
 
-  it('footer reset link calls update_app_state with welcomeShown:false + clear flags and flashes a confirmation', async () => {
+  it('shows a confirmation dialog before resetting onboarding flags', async () => {
     primeInitialLoads()
     renderSettings(<SettingsView onClose={vi.fn()} onOpenMigration={vi.fn()} onOpenAbout={vi.fn()} />)
     await waitFor(() => expect(screen.getByText('Claude Desktop')).toBeInTheDocument())
@@ -149,7 +153,13 @@ describe('SettingsView', () => {
       throw new Error(`unexpected command in test: ${command}`)
     })
 
-    await userEvent.setup().click(screen.getByRole('button', { name: /Reset onboarding flags/ }))
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Reset onboarding flags/ }))
+
+    expect(screen.getByRole('dialog', { name: /Reset onboarding state\?/ })).toBeInTheDocument()
+    expect(mockInvoke).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
 
     await waitFor(() =>
       expect(mockInvoke).toHaveBeenCalledWith('update_app_state', {
@@ -160,7 +170,24 @@ describe('SettingsView', () => {
         },
       }),
     )
-    expect(await screen.findByText(/Restart to see the welcome flow/)).toBeInTheDocument()
+  })
+
+  it('cancels reset when the user picks Cancel', async () => {
+    primeInitialLoads()
+    renderSettings(<SettingsView onClose={vi.fn()} onOpenMigration={vi.fn()} onOpenAbout={vi.fn()} />)
+    await waitFor(() => expect(screen.getByText('Claude Desktop')).toBeInTheDocument())
+
+    mockInvoke.mockReset()
+    mockInvoke.mockImplementation(async (command: string) => {
+      throw new Error(`unexpected command in test: ${command}`)
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /Reset onboarding flags/ }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(mockInvoke).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog', { name: /Reset onboarding state\?/ })).not.toBeInTheDocument()
   })
 
   it('appearance segmented control persists the theme via update_app_state', async () => {

--- a/apps/landing/src/components/hero.astro
+++ b/apps/landing/src/components/hero.astro
@@ -24,7 +24,7 @@ const repoUrl = 'https://github.com/bartekczyz/claude-profiles'
       View on GitHub
     </a>
   </div>
-  <p id="fineprint" class="font-mono text-[11.5px] text-muted">macOS 12+  ·  18 MB  ·  MIT</p>
+  <p id="fineprint" class="font-mono text-[11.5px] text-muted">macOS 12+  ·  MIT</p>
 </section>
 
 <script>

--- a/apps/landing/src/components/migration-explainer.astro
+++ b/apps/landing/src/components/migration-explainer.astro
@@ -1,0 +1,39 @@
+---
+---
+<section
+  aria-labelledby="migration-heading"
+  class="mx-auto max-w-[680px] px-4 pt-12 pb-4 sm:px-14"
+>
+  <h2
+    id="migration-heading"
+    class="m-0 mb-[18px] text-[22px] font-semibold tracking-[-0.014em]"
+  >
+    Already using Claude?
+  </h2>
+  <p class="m-0 mb-4 text-[15.5px] leading-[1.65] text-ink-soft">
+    On first launch, claude-profiles asks how you want to start. You pick
+    between two paths:
+  </p>
+  <ul class="m-0 mb-4 space-y-3 pl-5 text-[15.5px] leading-[1.65] text-ink-soft">
+    <li class="list-disc">
+      <strong>Keep separate</strong> (default). Your existing Claude stays put. Your new
+      profile lives alongside it. Both work independently — the new one is reached via
+      <code class="rounded bg-cream-2 px-1.5 py-px font-mono text-[0.88em]">claude-&lt;slug&gt;</code>.
+    </li>
+    <li class="list-disc">
+      <strong>Migrate.</strong> Your existing
+      <code class="rounded bg-cream-2 px-1.5 py-px font-mono text-[0.88em]">~/.claude</code>
+      becomes your first profile. From then on, use
+      <code class="rounded bg-cream-2 px-1.5 py-px font-mono text-[0.88em]">claude-&lt;slug&gt;</code>
+      — plain <code class="rounded bg-cream-2 px-1.5 py-px font-mono text-[0.88em]">claude</code>
+      will start a fresh install dir. Originals move to a 7-day backup you can restore from.
+    </li>
+  </ul>
+  <p class="m-0 text-[15.5px] leading-[1.65] text-ink-soft">
+    Either way, claude-profiles never reads or copies your Keychain
+    credentials. You'll log in once per migrated profile — that's a Claude
+    Code constraint (Keychain service names derive from
+    <code class="rounded bg-cream-2 px-1.5 py-px font-mono text-[0.88em]">CLAUDE_CONFIG_DIR</code>),
+    not ours.
+  </p>
+</section>

--- a/apps/landing/src/data/faq.ts
+++ b/apps/landing/src/data/faq.ts
@@ -17,7 +17,12 @@ export const faqEntries: ReadonlyArray<FaqEntry> = [
   {
     question: 'What if I already have Claude installed?',
     answer:
-      'On first launch, claude-profiles offers to import your existing install as a named profile so you do not lose history. You can skip this and migrate later from Settings.',
+      'On first launch, claude-profiles asks: (a) keep your existing Claude separate and start a new profile alongside it (default — press Enter), or (b) migrate your existing install into your first profile. The default leaves your current setup untouched and adds a separate profile reached via claude-<slug>. If you choose migrate, the data is copied into the profile dir and the originals are moved to a 7-day backup. You can trigger migration later from Settings → Data → Re-import.',
+  },
+  {
+    question: "What does 'migrate' actually do to my data?",
+    answer:
+      'Three things, in order: (1) copies ~/.claude and ~/Library/Application Support/Claude into the new profile directory under ~/Library/Application Support/claude-profiles/profiles/<id>/; (2) moves the originals into a 7-day backup dir under migration-backup-<timestamp>/; (3) generates a claude-<slug> CLI wrapper and a Claude (<Name>).app launcher. To revert: copy the backup folder contents back to their original locations.',
   },
   {
     question: 'Is it affiliated with Anthropic?',

--- a/apps/landing/src/lib/theme.test.ts
+++ b/apps/landing/src/lib/theme.test.ts
@@ -14,10 +14,4 @@ describe('themeScript', () => {
   it('falls back to light on error', () => {
     expect(themeScript).toContain("var theme = 'light'")
   })
-
-  it('preloads both screenshot variants with priority on the active theme', () => {
-    expect(themeScript).toContain("preload(theme, 'high')")
-    expect(themeScript).toContain("preload(other, 'low')")
-    expect(themeScript).toContain("'/screenshot-'")
-  })
 })

--- a/apps/landing/src/lib/theme.test.ts
+++ b/apps/landing/src/lib/theme.test.ts
@@ -12,6 +12,12 @@ describe('themeScript', () => {
   })
 
   it('falls back to light on error', () => {
-    expect(themeScript).toContain("setAttribute('data-theme', 'light')")
+    expect(themeScript).toContain("var theme = 'light'")
+  })
+
+  it('preloads both screenshot variants with priority on the active theme', () => {
+    expect(themeScript).toContain("preload(theme, 'high')")
+    expect(themeScript).toContain("preload(other, 'low')")
+    expect(themeScript).toContain("'/screenshot-'")
   })
 })

--- a/apps/landing/src/lib/theme.ts
+++ b/apps/landing/src/lib/theme.ts
@@ -2,16 +2,30 @@
  * No-flash theme script. Runs synchronously in <head> before the body
  * paints. Reads localStorage first (for a future explicit toggle),
  * falls back to prefers-color-scheme.
+ *
+ * Also preloads both app-screenshot variants — high priority on the
+ * current theme, low on the other — so the first theme toggle doesn't
+ * blink while the off-theme PNG is fetched on demand.
  */
 export const themeScript = `
 (function() {
+  var theme = 'light';
   try {
     var stored = localStorage.getItem('theme');
     var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    var theme = stored === 'light' || stored === 'dark' ? stored : (prefersDark ? 'dark' : 'light');
-    document.documentElement.setAttribute('data-theme', theme);
-  } catch (error) {
-    document.documentElement.setAttribute('data-theme', 'light');
+    theme = stored === 'light' || stored === 'dark' ? stored : (prefersDark ? 'dark' : 'light');
+  } catch (error) { /* fall through with 'light' */ }
+  document.documentElement.setAttribute('data-theme', theme);
+  var other = theme === 'dark' ? 'light' : 'dark';
+  function preload(name, priority) {
+    var link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'image';
+    link.href = '/screenshot-' + name + '.png';
+    link.fetchPriority = priority;
+    document.head.appendChild(link);
   }
+  preload(theme, 'high');
+  preload(other, 'low');
 })();
 `.trim()

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -6,6 +6,7 @@ import Footer from '../components/footer.astro'
 import Hero from '../components/hero.astro'
 import HowItWorks from '../components/how-it-works.astro'
 import InstallSection from '../components/install-section.astro'
+import MigrationExplainer from '../components/migration-explainer.astro'
 import TerminalStrip from '../components/terminal-strip.astro'
 import TopBar from '../components/top-bar.astro'
 import PageLayout from '../layouts/page.astro'
@@ -21,6 +22,7 @@ import PageLayout from '../layouts/page.astro'
     <AppScreenshot />
     <TerminalStrip />
     <HowItWorks />
+    <MigrationExplainer />
     <InstallSection />
     <FaqSection />
   </main>


### PR DESCRIPTION
## Summary

A pass over the first-launch flow plus the migration dialog plus a couple of bugs caught on the way.

- **Onboarding fork.** The first-launch auto-migration prompt is gone. Clicking "+ New profile" while no profiles exist and an existing Claude install is detected now opens a two-card fork dialog. "Just add a new profile, keep existing Claude as-is" is the default (Enter); "Migrate existing Claude into a profile" is the second option. All four create entry points (⌘N, sidebar, empty state, command palette) route through one centralized handler.
- **Migration dialog redesign.** Wider (760px) two-column layout: form on the left, a "What will happen" explainer card on the right with four numbered rows. Live `claude-<slug>` hint under the name input. Spinner + "Importing…" while the import is in flight; Cancel disabled during the same window. Skip button renamed to Cancel.
- **Reset onboarding flags.** Replaces the inline flash with a confirmation Dialog + success toast (and an error toast on failure).
- **Dark-mode button hover.** `secondary` / `danger` buttons get a `cream-3` hover surface in dark mode instead of the literal `bg-white` that read as a bright pill.
- **Updater fix.** Stopped forcing the platform key to `darwin-universal` — the published `latest.json` actually serves `darwin-aarch64` / `darwin-x86_64` (both pointing at the universal tarball), so the override caused every update check to fail with "the platform 'darwin-universal' was not found in the response 'platforms' object" in both dev and prod.
- **Landing: real DMG size.** Dropped the stale hardcoded `18 MB` from the hero fineprint. The existing script already reads `asset.size` from the GitHub Releases API and renders the real value (~11 MB) on first paint.
- **Landing: no-blink theme toggle.** Both screenshot variants are now preloaded from the head-time theme script — `fetchpriority="high"` on the active theme, `"low"` on the other — so the first switch is instant.
- **Docs.** New README "Onboarding" section. New landing "Already using Claude?" component between How it works and Install. FAQ rewritten to match the swapped default, plus a new "What does 'migrate' actually do to my data?" entry.

## Test plan

- [ ] `pnpm --filter claude-profiles test` — 162/162 passing locally.
- [ ] `pnpm --filter landing test` — 14/14 passing locally.
- [ ] `pnpm --filter claude-profiles typecheck` + `pnpm --filter landing typecheck` — clean.
- [ ] Open the migration dialog manually (Settings → Re-import or ⌘I) — two-column layout, slug preview live-updates, spinner shows on Import, headings align.
- [ ] Reset onboarding flags + restart the app — welcome dialog appears, empty state appears (no auto-prompt), "+ New profile" opens ChooseStartDialog with "Just add a new profile" auto-focused, pressing Enter goes to CreateProfileDialog.
- [ ] Click the migrate card → MigrationDialog opens.
- [ ] After creating one profile, "+ New profile" goes straight to CreateProfileDialog (fork only fires at zero profiles).
- [ ] In dark mode, hover the Re-import button in Settings → no bright white pill.
- [ ] Run a packaged build → updater check no longer surfaces the "darwin-universal" error.
- [ ] Visit the landing page, toggle theme → no blink on first switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)