### PR TITLE
perf: faster, less ugly app startup

### DIFF
--- a/apps/claude-profiles/index.html
+++ b/apps/claude-profiles/index.html
@@ -5,13 +5,10 @@
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
-  </head>
-
-  <body>
-    <div id="root"></div>
-    <!-- Initial theme paint — runs synchronously before React mounts so the cream/ink palette
-         is correct on first paint. ThemeProvider mirrors mode→localStorage on every change. -->
+    <title>claude-profiles</title>
+    <!-- Initial theme paint — runs before the body parses so the inline
+         styles below pick up [data-theme] for first paint. ThemeProvider
+         keeps the attribute in sync with the in-app toggle later. -->
     <script>
       (() => {
         try {
@@ -25,6 +22,48 @@
         }
       })()
     </script>
+    <!-- First-paint styles. The real design CSS arrives once the JS bundle
+         imports it; until then this block makes sure the window shows the
+         brand background (not browser-default white) and a small loader so
+         the user sees the app booting rather than a blank canvas. Hex
+         literals mirror `--color-base` in
+         packages/design-tokens/src/tokens.css so the steady-state paint
+         doesn't shift. -->
+    <style>
+      html, body { margin: 0; height: 100%; }
+      body {
+        background: #ede9dc;
+        color: #2a221c;
+        font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+      }
+      [data-theme="dark"] body { background: #0f0d0b; color: #ecdfd0; }
+      #root { height: 100%; }
+      .boot-loader {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+      }
+      .boot-loader > span {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: #d97757;
+        animation: boot-pulse 1.2s ease-in-out infinite;
+      }
+      @keyframes boot-pulse {
+        0%, 100% { transform: scale(0.7); opacity: 0.35; }
+        50%      { transform: scale(1.15); opacity: 1; }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root">
+      <div class="boot-loader" aria-hidden="true"><span></span></div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/claude-profiles/src-tauri/src/commands.rs
+++ b/apps/claude-profiles/src-tauri/src/commands.rs
@@ -4,7 +4,9 @@ use crate::activity::{self, Activity, ActivityKind};
 use crate::app_state::{self, AppState, AppStatePatch};
 use crate::deps::{self, Dependencies};
 use crate::error::{AppError, AppResult};
-use crate::migration::{self, ExistingInstall, ImportParams, MigrationBackupInfo};
+use crate::migration::{
+    self, ExistingInstall, ExistingInstallSizes, ImportParams, MigrationBackupInfo,
+};
 use crate::path_setup::{self, PathHookOutcome, Shell};
 use crate::paths::{
     activity_log_path, claude_code_install_path, claude_desktop_install_path, gui_launcher_path,
@@ -206,6 +208,18 @@ pub fn detect_existing_claude_install() -> AppResult<ExistingInstall> {
     let desktop = claude_desktop_install_path()?;
     let code = claude_code_install_path()?;
     Ok(migration::detect(&desktop, &code))
+}
+
+/// Lazy companion to `detect_existing_claude_install`. The boot-time
+/// detection skips the recursive directory walks because they can take
+/// 0.5–1s on a large `~/.claude`; the MigrationDialog calls this when
+/// it opens so the size column populates a beat later instead of
+/// blocking the whole app shell.
+#[tauri::command]
+pub fn detect_existing_claude_sizes() -> AppResult<ExistingInstallSizes> {
+    let desktop = claude_desktop_install_path()?;
+    let code = claude_code_install_path()?;
+    Ok(migration::detect_sizes(&desktop, &code))
 }
 
 #[derive(serde::Deserialize)]

--- a/apps/claude-profiles/src-tauri/src/deps.rs
+++ b/apps/claude-profiles/src-tauri/src/deps.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
@@ -19,12 +20,38 @@ pub struct Dependencies {
 
 pub fn check_dependencies() -> AppResult<Dependencies> {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-    let shell_path = get_shell_path().unwrap_or_default();
+    let shell_path = cached_shell_path(&home);
     Ok(Dependencies {
         claude_app_installed: claude_app_exists(),
         claude_cli_installed: find_claude_in_path(&shell_path, &home),
         local_bin_on_path: is_local_bin_in_path(&shell_path, &home),
     })
+}
+
+/// Process-lifetime cache for the resolved shell `PATH`. Spawning the
+/// interactive login shell to read `$PATH` costs 0.5–2 seconds on most
+/// macOS setups (NVM, brew, etc. all source on `-l`), so we only do it
+/// once per app launch.
+static SHELL_PATH_CACHE: OnceLock<String> = OnceLock::new();
+
+fn cached_shell_path(home: &Path) -> String {
+    SHELL_PATH_CACHE
+        .get_or_init(|| resolve_shell_path(home))
+        .clone()
+}
+
+/// Resolve the shell `PATH`. Fast path: if the process-inherited `PATH`
+/// already contains `~/.local/bin`, use that — Tauri tends to inherit a
+/// useful PATH on macOS unless the user launched the app from Finder
+/// before configuring their shell. Slow path: spawn the interactive
+/// login shell.
+fn resolve_shell_path(home: &Path) -> String {
+    if let Ok(process_path) = std::env::var("PATH") {
+        if is_local_bin_in_path(&process_path, home) {
+            return process_path;
+        }
+    }
+    get_shell_path().unwrap_or_default()
 }
 
 pub fn is_local_bin_in_path(path_string: &str, home: &Path) -> bool {

--- a/apps/claude-profiles/src-tauri/src/lib.rs
+++ b/apps/claude-profiles/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             commands::open_in_finder,
             commands::profile_paths,
             commands::detect_existing_claude_install,
+            commands::detect_existing_claude_sizes,
             commands::import_existing_install,
             commands::list_migration_backups,
             commands::delete_migration_backup,

--- a/apps/claude-profiles/src-tauri/src/migration.rs
+++ b/apps/claude-profiles/src-tauri/src/migration.rs
@@ -30,17 +30,39 @@ impl ExistingInstall {
     }
 }
 
-/// Pure: check the two well-known paths, report which exist, and walk
-/// each to compute its on-disk size. Production callers pass the real
-/// macOS paths; tests pass tempdir paths.
+/// Pure: check the two well-known paths and report which exist. Sizes
+/// are deliberately left `None` — this is the boot-critical-path entry
+/// and walking the trees synchronously can take a second or more on a
+/// large `~/.claude`. Use [`detect_sizes`] from a lazy IPC once the
+/// MigrationDialog opens.
 pub fn detect(claude_desktop_path: &Path, claude_code_path: &Path) -> ExistingInstall {
     let desktop_exists = claude_desktop_path.exists();
     let cli_exists = claude_code_path.exists();
     ExistingInstall {
         claude_desktop_path: desktop_exists.then(|| claude_desktop_path.display().to_string()),
         claude_code_path: cli_exists.then(|| claude_code_path.display().to_string()),
-        claude_desktop_size_bytes: desktop_exists.then(|| directory_size(claude_desktop_path)),
-        claude_code_size_bytes: cli_exists.then(|| directory_size(claude_code_path)),
+        claude_desktop_size_bytes: None,
+        claude_code_size_bytes: None,
+    }
+}
+
+/// Sizes-only side-table for [`detect`]. Walks each tree once; returns
+/// `None` for paths that don't exist.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExistingInstallSizes {
+    pub claude_desktop_size_bytes: Option<u64>,
+    pub claude_code_size_bytes: Option<u64>,
+}
+
+pub fn detect_sizes(claude_desktop_path: &Path, claude_code_path: &Path) -> ExistingInstallSizes {
+    ExistingInstallSizes {
+        claude_desktop_size_bytes: claude_desktop_path
+            .exists()
+            .then(|| directory_size(claude_desktop_path)),
+        claude_code_size_bytes: claude_code_path
+            .exists()
+            .then(|| directory_size(claude_code_path)),
     }
 }
 
@@ -360,15 +382,26 @@ mod tests {
     }
 
     #[test]
-    fn detect_computes_sizes_for_existing_installs() {
+    fn detect_leaves_sizes_none_so_boot_path_stays_fast() {
+        let scratch = tempdir().unwrap();
+        let desktop = scratch.path().join("Claude");
+        fs::create_dir_all(&desktop).unwrap();
+        fs::write(desktop.join("a.json"), b"0123456789").unwrap();
+        let info = detect(&desktop, &scratch.path().join("missing"));
+        assert_eq!(info.claude_desktop_size_bytes, None);
+        assert_eq!(info.claude_code_size_bytes, None);
+    }
+
+    #[test]
+    fn detect_sizes_walks_existing_trees() {
         let scratch = tempdir().unwrap();
         let desktop = scratch.path().join("Claude");
         fs::create_dir_all(desktop.join("nested")).unwrap();
         fs::write(desktop.join("a.json"), b"0123456789").unwrap(); // 10 bytes
         fs::write(desktop.join("nested/b.log"), b"abc").unwrap(); // 3 bytes
-        let info = detect(&desktop, &scratch.path().join("missing"));
-        assert_eq!(info.claude_desktop_size_bytes, Some(13));
-        assert_eq!(info.claude_code_size_bytes, None);
+        let sizes = detect_sizes(&desktop, &scratch.path().join("missing"));
+        assert_eq!(sizes.claude_desktop_size_bytes, Some(13));
+        assert_eq!(sizes.claude_code_size_bytes, None);
     }
 
     #[test]

--- a/apps/claude-profiles/src/features/migration/api/use-migration.ts
+++ b/apps/claude-profiles/src/features/migration/api/use-migration.ts
@@ -1,8 +1,8 @@
-import type { ExistingInstallInfo, ImportExistingInput, Profile } from '@/lib/types'
+import type { ExistingInstallInfo, ExistingInstallSizes, ImportExistingInput, Profile } from '@/lib/types'
 
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 
-import { detectExistingClaudeInstall, importExistingInstall } from '@/lib/commands'
+import { detectExistingClaudeInstall, detectExistingClaudeSizes, importExistingInstall } from '@/lib/commands'
 import { queryKeys } from '@/lib/query/keys'
 
 type UseMigrationResult = {
@@ -37,4 +37,22 @@ export function useMigration(): UseMigrationResult {
       await queryClient.invalidateQueries({ queryKey: queryKeys.migration.existing })
     },
   }
+}
+
+/**
+ * Lazy companion to `useMigration`. The path-existence query above runs
+ * at boot; this one only fires when something subscribes — typically the
+ * MigrationDialog when it opens — so the recursive `directory_size`
+ * walks happen off the boot critical path. Returns `null` for both
+ * sizes until the IPC resolves; the dialog shows the path without a
+ * size in the meantime.
+ */
+export function useMigrationSizes(enabled: boolean): ExistingInstallSizes {
+  const { data } = useQuery({
+    queryKey: queryKeys.migration.sizes,
+    queryFn: detectExistingClaudeSizes,
+    enabled,
+    staleTime: 60_000,
+  })
+  return data ?? { claudeDesktopSizeBytes: null, claudeCodeSizeBytes: null }
 }

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.test.tsx
@@ -1,10 +1,21 @@
 import type { ExistingInstallInfo, Profile } from '@/lib/types'
 
-import { render, screen } from '@testing-library/react'
+import { invoke } from '@tauri-apps/api/core'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderWithQuery } from '@/test/render-with-query'
 
 import { MigrationDialog } from './migration-dialog'
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }))
+
+const mockInvoke = vi.mocked(invoke)
+
+beforeEach(() => {
+  mockInvoke.mockReset()
+})
 
 const FAKE_PROFILE: Profile = {
   id: '1',
@@ -28,9 +39,17 @@ function existing(overrides: Partial<ExistingInstallInfo> = {}): ExistingInstall
 }
 
 function setup(detected: ExistingInstallInfo, overrides: Partial<Parameters<typeof MigrationDialog>[0]> = {}) {
+  // The dialog's lazy size query fires once it opens; resolve it
+  // immediately with the sizes the caller embedded in `existing`. Tests
+  // that override these (e.g. "omits the size span when size is missing")
+  // get the matching pre-stocked response.
+  mockInvoke.mockResolvedValue({
+    claudeDesktopSizeBytes: detected.claudeDesktopSizeBytes,
+    claudeCodeSizeBytes: detected.claudeCodeSizeBytes,
+  })
   const onClose = vi.fn()
   const onImport = vi.fn().mockResolvedValue(FAKE_PROFILE)
-  render(<MigrationDialog open existing={detected} onClose={onClose} onImport={onImport} {...overrides} />)
+  renderWithQuery(<MigrationDialog open existing={detected} onClose={onClose} onImport={onImport} {...overrides} />)
   return { onClose, onImport, user: userEvent.setup() }
 }
 
@@ -52,10 +71,12 @@ describe('MigrationDialog', () => {
     expect(screen.getByLabelText(/Claude Code CLI config/i)).toBeChecked()
   })
 
-  it('shows formatted sizes alongside each detected path', () => {
+  it('shows formatted sizes alongside each detected path', async () => {
     setup(existing())
-    expect(screen.getByText(/248 MB/)).toBeInTheDocument()
-    expect(screen.getByText(/4\.0 MB/)).toBeInTheDocument()
+    // Sizes arrive via the lazy `detect_existing_claude_sizes` query
+    // that fires when the dialog opens — wait for it.
+    expect(await screen.findByText(/248 MB/)).toBeInTheDocument()
+    expect(await screen.findByText(/4\.0 MB/)).toBeInTheDocument()
   })
 
   it('omits the size span when size is missing', () => {
@@ -87,9 +108,10 @@ describe('MigrationDialog', () => {
   })
 
   it('surfaces backend errors without closing', async () => {
+    mockInvoke.mockResolvedValue({ claudeDesktopSizeBytes: null, claudeCodeSizeBytes: null })
     const onImport = vi.fn().mockRejectedValue(new Error('disk full'))
     const onClose = vi.fn()
-    render(
+    renderWithQuery(
       <MigrationDialog
         open
         existing={existing({ claudeCodePath: null, claudeCodeSizeBytes: null })}

--- a/apps/claude-profiles/src/features/migration/components/migration-dialog.tsx
+++ b/apps/claude-profiles/src/features/migration/components/migration-dialog.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { Loader2 } from 'lucide-react'
 
 import { Button, Dialog, Kbd, StatusDot } from '@/design'
+import { useMigrationSizes } from '@/features/migration/api/use-migration'
 // cross-feature: migration dialog reuses the profile color picker for the imported profile
 import { ColorSwatchPicker } from '@/features/profiles/components/color-swatch-picker'
 import { slugifyPreview } from '@/features/profiles/components/profile-form-fields'
@@ -27,6 +28,10 @@ function shorten(absolutePath: string): string {
 }
 
 export function MigrationDialog({ open, existing, onClose, onImport }: Props) {
+  // Size walks happen off the boot critical path — this hook only fires
+  // while the dialog is open, so the size column populates a beat after
+  // the dialog appears rather than blocking app startup.
+  const sizes = useMigrationSizes(open)
   const [name, setName] = useState('Default')
   const [color, setColor] = useState<string>(presetColors[0])
   const [includeGui, setIncludeGui] = useState(existing.claudeDesktopPath !== null)
@@ -86,14 +91,14 @@ export function MigrationDialog({ open, existing, onClose, onImport }: Props) {
                 <DetectedRow
                   label="Claude Desktop"
                   path={existing.claudeDesktopPath}
-                  sizeBytes={existing.claudeDesktopSizeBytes}
+                  sizeBytes={sizes.claudeDesktopSizeBytes}
                 />
               ) : null}
               {existing.claudeCodePath ? (
                 <DetectedRow
                   label="Claude Code CLI"
                   path={existing.claudeCodePath}
-                  sizeBytes={existing.claudeCodeSizeBytes}
+                  sizeBytes={sizes.claudeCodeSizeBytes}
                 />
               ) : null}
             </ul>

--- a/apps/claude-profiles/src/lib/commands.ts
+++ b/apps/claude-profiles/src/lib/commands.ts
@@ -6,6 +6,7 @@ import type {
   AppStatePatch,
   Dependencies,
   ExistingInstallInfo,
+  ExistingInstallSizes,
   ImportExistingInput,
   MigrationBackupInfo,
   PathHookOutcome,
@@ -74,6 +75,10 @@ export function copyToClipboard(text: string): Promise<void> {
 
 export function detectExistingClaudeInstall(): Promise<ExistingInstallInfo> {
   return invoke<ExistingInstallInfo>('detect_existing_claude_install')
+}
+
+export function detectExistingClaudeSizes(): Promise<ExistingInstallSizes> {
+  return invoke<ExistingInstallSizes>('detect_existing_claude_sizes')
 }
 
 export function importExistingInstall(input: ImportExistingInput): Promise<Profile> {

--- a/apps/claude-profiles/src/lib/query/keys.ts
+++ b/apps/claude-profiles/src/lib/query/keys.ts
@@ -15,6 +15,7 @@ export const queryKeys = {
   dependencies: ['dependencies'] as const,
   migration: {
     existing: ['migration', 'existing'] as const,
+    sizes: ['migration', 'sizes'] as const,
     backups: ['migration', 'backups'] as const,
   },
   appState: ['app-state'] as const,

--- a/apps/claude-profiles/src/lib/types.ts
+++ b/apps/claude-profiles/src/lib/types.ts
@@ -57,10 +57,18 @@ export type ExistingInstallInfo = {
   claudeCodePath: string | null
   /**
    * Bytes on disk for each detected install. `null` when the corresponding
-   * path is also `null` (nothing detected); permission-denied subpaths
-   * during the walk are silently skipped on the Rust side, so the value is
+   * path is also `null` (nothing detected) OR when the size walk hasn't
+   * run yet — the boot-time `detect_existing_claude_install` IPC returns
+   * `null` here to keep startup fast; sizes arrive later via
+   * `detect_existing_claude_sizes`. Permission-denied subpaths during the
+   * walk are silently skipped on the Rust side, so the eventual value is
    * best-effort.
    */
+  claudeDesktopSizeBytes: number | null
+  claudeCodeSizeBytes: number | null
+}
+
+export type ExistingInstallSizes = {
   claudeDesktopSizeBytes: number | null
   claudeCodeSizeBytes: number | null
 }


### PR DESCRIPTION
## Summary

Three changes that together turn the boot sequence from "white window → 1-2s blank → 1s skeleton → app" into "brand background + loader immediately → skeleton briefly → app".

### Visual (`fix(boot)`)

The window opened with the browser default white because the body's cream/dark background lives in CSS that the JS bundle only imports after it parses. Added an inline `<style>` block in `index.html` that paints the brand background (literal `#ede9dc` / `#0f0d0b` matching `--color-base`, keyed off `[data-theme]` which the existing inline theme script already sets before the body parses) and a small centered orange pulse so first paint shows the app booting instead of a blank canvas. Also fixed the page title from "Tauri + React + Typescript".

### Rust: `check_dependencies` (`perf(deps)`)

The IPC was spawning the user's interactive login shell (`zsh -lic 'echo $PATH'`) on every cold call — 0.5-2s on most macOS setups (NVM, brew, pyenv all source on `-l`). React Query cached the result per session but boot paid the full price.

- Try `std::env::var("PATH")` first; if it already contains `~/.local/bin`, skip the shell spawn entirely.
- Otherwise spawn the interactive shell, but cache the resolved value in a `OnceLock` so repeat calls within the process never re-spawn.

### Rust + React: migration size walks (`perf(migration)`)

`detect_existing_claude_install` recursively walked `~/.claude` and `~/Library/Application Support/Claude` on every boot to compute sizes for the MigrationDialog — multi-GB project history added measurable lag to the AppShellSkeleton wait.

Split the IPC:
- `detect_existing_claude_install` now just checks path existence (~5ms). Stays on the boot suspense path.
- `detect_existing_claude_sizes` is a new lazy IPC that does the size walk. MigrationDialog subscribes via a new `useMigrationSizes` hook when it opens, so sizes populate a beat after the dialog appears instead of blocking app startup.

## Test plan

- [ ] `pnpm --filter claude-profiles test` — 154/154.
- [ ] `pnpm --filter landing test` — 13/13.
- [ ] `pnpm --filter claude-profiles typecheck` + landing typecheck — clean.
- [ ] `cargo test` — 106/106.
- [ ] `pnpm --filter claude-profiles tauri dev` — window opens with cream/dark base + pulsing orange dot, not white; app shell appears quickly; skeleton brief.
- [ ] Open the migration dialog (Settings → Re-import or ⌘I): the size column shows "—" for a moment, then populates with the real sizes.
- [ ] On dark mode the first paint matches the steady-state dark background, no flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)