### PR TITLE
fix(updater): relaunch the app after downloadAndInstall

### DIFF
--- a/apps/claude-profiles/package.json
+++ b/apps/claude-profiles/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/api": "2.11.0",
     "@tauri-apps/plugin-clipboard-manager": "2.3.2",
     "@tauri-apps/plugin-fs": "2.5.1",
+    "@tauri-apps/plugin-process": "~2",
     "@tauri-apps/plugin-updater": "~2",
     "@tauri-apps/plugin-window-state": "~2",
     "class-variance-authority": "0.7.1",

--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -373,6 +373,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-fs",
+ "tauri-plugin-process",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
@@ -3638,6 +3639,16 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tauri-plugin-clipboard-manager = "2"
 tempfile = "3.27.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 

--- a/apps/claude-profiles/src-tauri/capabilities/desktop.json
+++ b/apps/claude-profiles/src-tauri/capabilities/desktop.json
@@ -2,5 +2,5 @@
   "identifier": "desktop-capability",
   "platforms": ["macOS", "windows", "linux"],
   "windows": ["main"],
-  "permissions": ["window-state:default", "updater:default"]
+  "permissions": ["window-state:default", "updater:default", "process:allow-restart"]
 }

--- a/apps/claude-profiles/src-tauri/src/lib.rs
+++ b/apps/claude-profiles/src-tauri/src/lib.rs
@@ -27,6 +27,10 @@ const OPEN_ABOUT_ID: &str = "open-about";
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // Provides `relaunch()` to the frontend so the updater can restart
+        // the app itself after `downloadAndInstall` finishes — Tauri 2's
+        // updater plugin does NOT relaunch on its own.
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_fs::init())

--- a/apps/claude-profiles/src/features/updater/api/use-updater.ts
+++ b/apps/claude-profiles/src/features/updater/api/use-updater.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 import { useEffect, useState } from 'react'
 
+import { relaunch } from '@tauri-apps/plugin-process'
 import { check, type Update } from '@tauri-apps/plugin-updater'
 
 type UpdaterStatus =
@@ -38,8 +39,10 @@ async function runCheckInto(setStatus: StatusSetter): Promise<void> {
  * triggers so the toast component and Settings → System can drive their
  * own UI from the same source of truth.
  *
- * The plugin's `downloadAndInstall` restarts the app itself on success, so
- * there's no `restart` call here.
+ * Tauri 2's `downloadAndInstall` does NOT relaunch the app on its own —
+ * the process plugin's `relaunch()` has to be called explicitly after,
+ * otherwise the user sees "Installing…" forever and has to manually
+ * quit + reopen to pick up the new binary.
  *
  * Implementation note: the polling body lives in `runCheckInto` (a
  * module-level function) so the effect dependency list stays empty — the
@@ -61,6 +64,7 @@ export function useUpdater() {
     setStatus({ kind: 'installing' })
     try {
       await update.downloadAndInstall()
+      await relaunch()
     } catch (caught) {
       setStatus({
         kind: 'error',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: 2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-process':
+        specifier: ~2
+        version: 2.3.1
       '@tauri-apps/plugin-updater':
         specifier: ~2
         version: 2.10.1
@@ -2288,6 +2291,9 @@ packages:
 
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
@@ -7074,6 +7080,10 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-fs@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-process@2.3.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 


### PR DESCRIPTION
## Summary

Auto-update was getting stuck on "Installing…" forever after a successful download because Tauri 2's \`downloadAndInstall()\` does *not* relaunch the app on its own — it only swaps the bundle on disk. The hook's old comment claimed it relaunches automatically, which is wrong.

Visible symptom: user clicked "Restart and install", saw "Installing…", then had to quit + reopen manually to pick up the new binary.

## Fix

Wire up \`@tauri-apps/plugin-process\` and call \`relaunch()\` immediately after \`downloadAndInstall()\` resolves:

- \`apps/claude-profiles/src-tauri/Cargo.toml\`: add \`tauri-plugin-process = "2"\`.
- \`apps/claude-profiles/src-tauri/src/lib.rs\`: register \`tauri_plugin_process::init()\`.
- \`apps/claude-profiles/src-tauri/capabilities/desktop.json\`: grant \`process:allow-restart\` on the main window.
- \`apps/claude-profiles/package.json\`: add \`@tauri-apps/plugin-process\`.
- \`apps/claude-profiles/src/features/updater/api/use-updater.ts\`: import \`relaunch\` and call it after \`update.downloadAndInstall()\`.

Also rewrites the comment on \`useUpdater\` so the next person reading it knows the relaunch is mandatory.

## Test plan

- [ ] \`pnpm --filter claude-profiles test\` — 154/154.
- [ ] \`cargo test\` — 106/106.
- [ ] Once v0.2.2 ships, an installed v0.2.1 will be offered an update. Click "Restart and install" — the app should auto-relaunch into the new version with no manual quit/reopen.
- [ ] Locally: edit \`tauri.conf.json\` version to a value lower than the published release (e.g. 0.2.0), \`pnpm --filter claude-profiles tauri dev\`, trigger the update from Settings → System → Restart and install. App should relaunch automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)