### PR TITLE
fix(about): correct version display and tidy About / Settings

### DIFF
--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "claude-profiles"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "dirs",

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-profiles"
-version = "0.1.0"
+version = "0.2.2"
 description = "Run multiple Claude accounts on one Mac, each with its own isolated Desktop launcher and CLI wrapper."
 authors = ["Bartek Czyż <bartek@czyz.it>"]
 repository = "https://github.com/bartekczyz/claude-profiles"

--- a/apps/claude-profiles/src/features/about/components/about-dialog.tsx
+++ b/apps/claude-profiles/src/features/about/components/about-dialog.tsx
@@ -30,8 +30,7 @@ export function AboutDialog({ open, onClose }: Props) {
   return (
     <Dialog
       open={open}
-      title={metadata.name}
-      description={metadata.description}
+      title="About claude-profiles"
       onClose={onClose}
       foot={
         <Button variant="primary" size="sm" trailingKbd={<Kbd variant="onOrange">⎋</Kbd>} onClick={onClose}>

--- a/apps/claude-profiles/src/features/settings/components/settings-view.test.tsx
+++ b/apps/claude-profiles/src/features/settings/components/settings-view.test.tsx
@@ -43,6 +43,16 @@ const DEFAULT_EXISTING = {
   claudeCodeSizeBytes: null,
 }
 
+const DEFAULT_METADATA = {
+  name: 'claude-profiles',
+  version: '0.1.0',
+  description: 'Test description',
+  authors: ['Bartek Czyż <bartek@czyz.it>'],
+  repository: null,
+  homepage: null,
+  license: 'MIT',
+}
+
 beforeEach(() => {
   mockInvoke.mockReset()
 })
@@ -56,12 +66,14 @@ function primeInitialLoads({
   state = DEFAULT_STATE,
   shell = 'zsh',
   existing = DEFAULT_EXISTING,
+  metadata = DEFAULT_METADATA,
 }: {
   deps?: unknown
   backups?: Array<unknown>
   state?: unknown
   shell?: string
   existing?: unknown
+  metadata?: unknown
 } = {}) {
   mockInvoke.mockImplementation(async (command: string) => {
     if (command === 'check_dependencies') {
@@ -78,6 +90,9 @@ function primeInitialLoads({
     }
     if (command === 'detect_existing_claude_install') {
       return existing
+    }
+    if (command === 'get_app_metadata') {
+      return metadata
     }
     throw new Error(`unexpected command in test: ${command}`)
   })

--- a/apps/claude-profiles/src/features/settings/components/system-section.tsx
+++ b/apps/claude-profiles/src/features/settings/components/system-section.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { RotateCw } from 'lucide-react'
 
 import { Button, Skeleton, StatusDot } from '@/design'
+import { useAppMetadata } from '@/features/about/api/use-app-metadata'
 import { useDependencies } from '@/features/dependencies/api/use-dependencies'
 import { type UpdaterStatus, useUpdater } from '@/features/updater/api/use-updater'
 import { detectShell, installPathHook } from '@/lib/commands'
@@ -20,6 +21,7 @@ type Row = {
   label: string
   tone: StatusTone
   detail: string
+  aux?: string
 }
 
 function describeUpdaterStatus(status: UpdaterStatus): { tone: StatusTone; detail: string } {
@@ -50,6 +52,7 @@ function buildRows(
   deps: { claudeAppInstalled: boolean; claudeCliInstalled: boolean; localBinOnPath: boolean },
   shell: Shell | null,
   updater: { tone: StatusTone; detail: string },
+  version: string,
 ): Array<Row> {
   return [
     {
@@ -71,6 +74,7 @@ function buildRows(
       label: 'Updates',
       tone: updater.tone,
       detail: updater.detail,
+      aux: `v${version}`,
     },
   ]
 }
@@ -93,6 +97,7 @@ function buildRows(
 export function SystemSection() {
   const dependencies = useDependencies()
   const updater = useUpdater()
+  const { version } = useAppMetadata()
   const [shell, setShell] = useState<Shell | null>(null)
   const [hookMessage, setHookMessage] = useState<string | null>(null)
   const [hookError, setHookError] = useState<string | null>(null)
@@ -149,7 +154,7 @@ export function SystemSection() {
   }
 
   const updaterDescription = describeUpdaterStatus(updater.status)
-  const rows = buildRows(dependencies.deps, shell, updaterDescription)
+  const rows = buildRows(dependencies.deps, shell, updaterDescription, version)
   const hookInstalled = dependencies.deps.localBinOnPath && shell !== null
   const updateCheckBusy = updater.status.kind === 'checking' || updater.status.kind === 'installing'
   const updateActionLabel = updater.status.kind === 'available' ? 'Restart and install' : 'Check now'
@@ -184,7 +189,10 @@ export function SystemSection() {
             className="grid grid-cols-[7px_1fr_auto] items-center gap-3 border-b border-border-soft px-4 py-3 text-[13px] tracking-[-0.003em] text-ink-soft last:border-b-0"
           >
             <StatusDot tone={row.tone} pulse />
-            <span>{row.label}</span>
+            <span>
+              {row.label}
+              {row.aux ? <span className="ml-2 font-mono text-[11.5px] text-muted">{row.aux}</span> : null}
+            </span>
             <span className="font-mono text-[11.5px] text-muted">{row.detail}</span>
           </div>
         ))}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -32,6 +32,11 @@
           "type": "json",
           "path": "src-tauri/tauri.conf.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "src-tauri/Cargo.toml",
+          "jsonpath": "$.package.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- About dialog was rendering version `0.1.0` because `get_app_metadata` reads `env!("CARGO_PKG_VERSION")` but release-please only bumped `package.json` and `tauri.conf.json`. Sync `src-tauri/Cargo.toml` to 0.2.2 and add it to release-please `extra-files` so future releases stay aligned.
- About dialog header was titled `claude-profiles` with the full Cargo description as a subtitle, which read more like a tagline than a dialog header. Title becomes `About claude-profiles`; the subtitle is dropped — the version row inside carries the rest.
- Settings → System never surfaced the running version, only the updater state. Inline `v{version}` as muted mono text right after the `Updates` label so the row reads `● Updates v0.2.2                Up to date`. Sourced from the existing `useAppMetadata()` suspense query (which `AboutDialog` already drives) — no extra `useEffect`/`getVersion` plumbing.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 154/154 passing
- [ ] Open About — title reads "About claude-profiles", no subtitle, version row shows `v0.2.2`
- [ ] Open Settings → System — Updates row reads `● Updates v0.2.2 … Up to date`
- [ ] Next release-please PR bumps `src-tauri/Cargo.toml` alongside `package.json` and `tauri.conf.json`