### PR TITLE
feat(usage): per-profile Claude usage stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Already using Claude Desktop or Claude Code? On first launch the app offers to i
 
 Deleting a profile from its detail view removes the launcher and CLI wrapper; the profile's data either goes to the Trash or is deleted outright, your choice.
 
+### Usage stats
+
+Each profile's detail page shows that profile's current Claude utilization — the same numbers you'd see in `/usage` inside Claude Code, but visible alongside the launcher and CLI wrapper buttons. Three meters: the rolling 5-hour window, the 7-day window, and the 7-day Sonnet sub-window, each with a percentage and a relative reset time. A small countdown tells you when the next auto-refresh will fire (every 5 minutes while the card is visible), or you can hit the ↻ button to refresh on demand.
+
+Under the hood the card calls Anthropic's `/api/oauth/usage` endpoint using the profile's own OAuth token, read from the macOS Keychain entry Claude Code created when you signed in.
+
+Same caveat as the rest of the app: the quota endpoint and the Keychain naming convention are undocumented Anthropic internals. If either changes, the meters may show `—` until we ship a patch.
+
 ## Onboarding
 
 **First launch.** A welcome dialog appears once; after that you land on the empty state with a single "+ New profile" CTA. There is no auto-prompt — the next step is on you.
@@ -104,6 +112,9 @@ Yes — Settings → Data → "Detect and import…".
 
 **Is this safe? What about my Keychain credentials?**
 Each profile gets a separate Keychain entry derived from its config directory. We don't read or copy your credentials; Claude Code handles all of that. The CLI isolation behavior depends on undocumented Claude Code internals (its SHA-256 service-name derivation), and could break in a future Claude Code release. If it does we'll patch.
+
+**The usage meters on the profile detail page show `—` instead of numbers — what's wrong?**
+The card calls Anthropic's `/api/oauth/usage` endpoint, which is undocumented and may change shape without notice. If the response stops matching what we parse, the affected meters render as `—` rather than crashing. The local token breakdown disclosure underneath the meters keeps working regardless — it's derived from your CLI transcripts on disk. If you see persistent dashes, file an issue and we'll patch. Note that the first refresh after a fresh install triggers a macOS Keychain access prompt — click "Always Allow" so it doesn't recur.
 
 **Why "Settings" instead of "Preferences"?**
 macOS deprecated "Preferences" in favor of "Settings" in Ventura. We follow the current convention.

--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -3383,6 +3383,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4124,6 +4134,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",

--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -78,6 +78,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +433,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "cookie"
@@ -4315,12 +4345,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -346,6 +346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,12 +367,13 @@ dependencies = [
 
 [[package]]
 name = "claude-profiles"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs",
  "icns",
  "plist",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -378,6 +385,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "trash",
  "uuid",
 ]
@@ -1148,8 +1156,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1159,9 +1169,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1466,6 +1478,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1941,6 +1954,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2544,6 +2563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2671,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2745,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2737,6 +2849,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "reqwest"
@@ -2851,6 +3001,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2897,6 +3048,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3118,6 +3275,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3503,7 +3672,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3667,7 +3836,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.3",
  "rustls",
  "semver",
  "serde",
@@ -3943,7 +4112,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4600,6 +4781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4660,6 +4851,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -78,6 +78,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +380,7 @@ dependencies = [
 name = "claude-profiles"
 version = "0.3.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "dirs",
  "icns",

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ icns = "0.4.0"
 plist = "1.9.0"
 trash = "5.2.6"
 tauri-plugin-clipboard-manager = "2"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "gzip", "brotli", "deflate"] }
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "macros", "process", "time"] }
 

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ trash = "5.2.6"
 tauri-plugin-clipboard-manager = "2"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 sha2 = "0.10"
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "macros", "process", "time"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ plist = "1.9.0"
 trash = "5.2.6"
 tauri-plugin-clipboard-manager = "2"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+async-trait = "0.1"
 dirs = "6"
 icns = "0.4.0"
 plist = "1.9.0"

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -33,6 +33,8 @@ icns = "0.4.0"
 plist = "1.9.0"
 trash = "5.2.6"
 tauri-plugin-clipboard-manager = "2"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/apps/claude-profiles/src-tauri/src/commands.rs
+++ b/apps/claude-profiles/src-tauri/src/commands.rs
@@ -414,5 +414,6 @@ pub async fn get_profile_usage(profile_id: String) -> AppResult<ProfileUsage> {
     let cli_config = profile_root.join("cli-config");
     let client = ReqwestUsageClient::new(format!("claude-profiles/{}", env!("CARGO_PKG_VERSION")))
         .map_err(|_| AppError::Io(std::io::Error::other("could not build HTTP client")))?;
-    Ok(usage::build(&cli_config, &client).await)
+    let refresher = usage::refresh::ClaudeCliRefresher;
+    Ok(usage::build_with_cli_refresh(&cli_config, &client, &refresher).await)
 }

--- a/apps/claude-profiles/src-tauri/src/commands.rs
+++ b/apps/claude-profiles/src-tauri/src/commands.rs
@@ -13,6 +13,7 @@ use crate::paths::{
     next_migration_backup_dir, profile_dir as profile_data_dir,
 };
 use crate::profiles::{self, Profile, ProfilePatch, ProfilePaths, Surface, Surfaces};
+use crate::usage::{self, quota::ReqwestUsageClient, ProfileUsage};
 
 /// Append an activity entry to the profile's log. Failures are logged
 /// but do not propagate — the log is best-effort, not load-bearing.
@@ -405,4 +406,13 @@ pub fn get_app_metadata() -> AppMetadata {
         homepage: optional(env!("CARGO_PKG_HOMEPAGE")),
         license: optional(env!("CARGO_PKG_LICENSE")),
     }
+}
+
+#[tauri::command]
+pub async fn get_profile_usage(profile_id: String) -> AppResult<ProfileUsage> {
+    let profile_root = profile_data_dir(&profile_id)?;
+    let cli_config = profile_root.join("cli-config");
+    let client = ReqwestUsageClient::new(format!("claude-profiles/{}", env!("CARGO_PKG_VERSION")))
+        .map_err(|_| AppError::Io(std::io::Error::other("could not build HTTP client")))?;
+    Ok(usage::build(&cli_config, &client).await)
 }

--- a/apps/claude-profiles/src-tauri/src/commands.rs
+++ b/apps/claude-profiles/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::sync::OnceLock;
 
 use crate::activity::{self, Activity, ActivityKind};
 use crate::app_state::{self, AppState, AppStatePatch};
@@ -408,12 +409,19 @@ pub fn get_app_metadata() -> AppMetadata {
     }
 }
 
+/// One shared refresher across all `get_profile_usage` invocations so
+/// its per-profile mutex + backoff registry survives across calls.
+/// A new instance per command would defeat both: two simultaneous
+/// commands on the same profile would race, and a 5-minute auto-refetch
+/// would never see the previous "tried at" timestamp.
+static REFRESHER: OnceLock<usage::refresh::ClaudeCliRefresher> = OnceLock::new();
+
 #[tauri::command]
 pub async fn get_profile_usage(profile_id: String) -> AppResult<ProfileUsage> {
     let profile_root = profile_data_dir(&profile_id)?;
     let cli_config = profile_root.join("cli-config");
     let client = ReqwestUsageClient::new(format!("claude-profiles/{}", env!("CARGO_PKG_VERSION")))
         .map_err(|_| AppError::Io(std::io::Error::other("could not build HTTP client")))?;
-    let refresher = usage::refresh::ClaudeCliRefresher;
-    Ok(usage::build_with_cli_refresh(&cli_config, &client, &refresher).await)
+    let refresher = REFRESHER.get_or_init(usage::refresh::ClaudeCliRefresher::new);
+    Ok(usage::build_with_cli_refresh(&cli_config, &client, refresher).await)
 }

--- a/apps/claude-profiles/src-tauri/src/lib.rs
+++ b/apps/claude-profiles/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             commands::list_activity,
             commands::record_activity,
             commands::get_app_metadata,
+            commands::get_profile_usage,
             commands::open_external_url,
         ])
         .run(tauri::generate_context!())

--- a/apps/claude-profiles/src-tauri/src/lib.rs
+++ b/apps/claude-profiles/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod profiles;
 mod slug;
 #[cfg(test)]
 mod test_support;
+mod usage;
 
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::Emitter;

--- a/apps/claude-profiles/src-tauri/src/usage/credentials.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/credentials.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+#[cfg(target_os = "macos")]
 use std::process::Command;
 
 use serde::Deserialize;
@@ -12,6 +13,7 @@ use crate::usage::QuotaError;
 const MAX_CREDENTIALS_BYTES: u64 = 64 * 1024;
 
 /// Hard cap on the keychain secret size. The real secret is well under 1 KiB.
+#[cfg(target_os = "macos")]
 const MAX_KEYCHAIN_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Deserialize, Default)]
@@ -32,8 +34,14 @@ struct ClaudeOauth {
 ///
 /// Order:
 /// 1. `<cli_config_dir>/.credentials.json` (Linux/Windows; older macOS Claude Code).
-/// 2. macOS Keychain, querying `Claude Code-credentials-<sha256(cli_config_dir)[:8]>`
-///    against the current user (newer Claude Code on macOS — the default).
+/// 2. macOS only: Keychain, querying
+///    `Claude Code-credentials-<sha256(cli_config_dir)[:8]>` against the
+///    current user (newer Claude Code on macOS — the default).
+///
+/// On non-macOS platforms the keychain step is skipped — if the file
+/// isn't present we return `NoCredentials` so the UI shows the standard
+/// "sign in to Claude Code once with this profile" message rather than
+/// failing as `Unknown` from a missing `/usr/bin/security`.
 ///
 /// On any failure returns a categorised `QuotaError`. Never panics.
 pub fn read_access_token(cli_config_dir: &Path) -> Result<String, QuotaError> {
@@ -62,6 +70,7 @@ fn read_from_file(path: &Path) -> Result<String, QuotaError> {
     extract_token(&raw)
 }
 
+#[cfg(target_os = "macos")]
 fn read_from_keychain(cli_config_dir: &Path) -> Result<String, QuotaError> {
     let service = keychain_service_name(cli_config_dir);
     // Account name is the current macOS user. Fall back to the empty
@@ -96,6 +105,15 @@ fn read_from_keychain(cli_config_dir: &Path) -> Result<String, QuotaError> {
         Err(_) => return Err(QuotaError::Unknown),
     };
     extract_token(raw.trim())
+}
+
+/// Non-macOS stub: there's no Apple Keychain to query, so if the
+/// credentials file wasn't present the user simply hasn't signed in
+/// to Claude Code on this profile yet. Surfacing `NoCredentials` keeps
+/// the UI consistent across platforms.
+#[cfg(not(target_os = "macos"))]
+fn read_from_keychain(_cli_config_dir: &Path) -> Result<String, QuotaError> {
+    Err(QuotaError::NoCredentials)
 }
 
 /// Pure: compute the macOS Keychain service name Claude Code uses for
@@ -244,19 +262,17 @@ mod tests {
     // -- cascade behavior --
 
     #[test]
-    fn missing_file_cascades_to_keychain_then_no_credentials_when_not_present() {
-        // No credentials file → falls through to keychain → keychain
-        // entry won't exist for this random tempdir path → NoCredentials.
-        // This is an integration check: it runs `security` against a
-        // tempdir-derived service name that won't exist. On non-macOS
-        // platforms `security` isn't available and `Command::new` will
-        // fail with Unknown — accept either NoCredentials or Unknown
-        // here so the test passes in CI on Linux too.
+    fn missing_file_returns_no_credentials() {
+        // No credentials file → on macOS we fall through to keychain
+        // (no entry exists for a random tempdir → exit 44 → NoCredentials);
+        // on other platforms the keychain step is stubbed out and we
+        // return NoCredentials directly. Either way the user sees the
+        // same "sign in once" message.
         let dir = TempDir::new().unwrap();
         let outcome = read_access_token(dir.path()).unwrap_err();
         assert!(
-            matches!(outcome, QuotaError::NoCredentials | QuotaError::Unknown),
-            "expected NoCredentials or Unknown, got {outcome:?}",
+            matches!(outcome, QuotaError::NoCredentials),
+            "expected NoCredentials, got {outcome:?}",
         );
     }
 

--- a/apps/claude-profiles/src-tauri/src/usage/credentials.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/credentials.rs
@@ -120,9 +120,19 @@ fn extract_token(raw: &str) -> Result<String, QuotaError> {
         Ok(value) => value,
         Err(_) => return Err(QuotaError::Unknown),
     };
+    // Trim whitespace from the stored token before returning it. A
+    // trailing newline or stray space would otherwise be sent as part
+    // of the `Authorization: Bearer …` header and rejected as 401.
     match parsed.claude_ai_oauth.access_token {
-        Some(token) if !token.trim().is_empty() => Ok(token),
-        _ => Err(QuotaError::NoCredentials),
+        Some(token) => {
+            let trimmed = token.trim();
+            if trimmed.is_empty() {
+                Err(QuotaError::NoCredentials)
+            } else {
+                Ok(trimmed.to_string())
+            }
+        }
+        None => Err(QuotaError::NoCredentials),
     }
 }
 
@@ -256,5 +266,13 @@ mod tests {
     fn extract_token_parses_keychain_style_blob() {
         let blob = r#"{"claudeAiOauth":{"accessToken":"sk-ant-from-keychain","refreshToken":"sk-ant-refresh","email":"x@y.z","expiresAt":1234567890000}}"#;
         assert_eq!(extract_token(blob).unwrap(), "sk-ant-from-keychain");
+    }
+
+    #[test]
+    fn extract_token_trims_surrounding_whitespace() {
+        // A trailing newline or stray space in the stored value would
+        // otherwise be sent as part of the Bearer header and 401.
+        let blob = r#"{"claudeAiOauth":{"accessToken":"  sk-ant-padded \n"}}"#;
+        assert_eq!(extract_token(blob).unwrap(), "sk-ant-padded");
     }
 }

--- a/apps/claude-profiles/src-tauri/src/usage/credentials.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/credentials.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
+use std::process::Command;
 
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 use crate::usage::QuotaError;
 
@@ -8,6 +10,9 @@ use crate::usage::QuotaError;
 /// (a few hundred bytes). Anything larger is treated as suspect
 /// and rejected rather than read into memory.
 const MAX_CREDENTIALS_BYTES: u64 = 64 * 1024;
+
+/// Hard cap on the keychain secret size. The real secret is well under 1 KiB.
+const MAX_KEYCHAIN_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Deserialize, Default)]
 struct CredentialsFile {
@@ -23,12 +28,24 @@ struct ClaudeOauth {
     access_token: Option<String>,
 }
 
-/// Reads the access token from `<cli_config_dir>/.credentials.json`.
-/// On any failure (missing file, oversized, unreadable, malformed JSON,
-/// empty token) returns a categorised `QuotaError`. Never panics.
+/// Reads the OAuth access token for a profile.
+///
+/// Order:
+/// 1. `<cli_config_dir>/.credentials.json` (Linux/Windows; older macOS Claude Code).
+/// 2. macOS Keychain, querying `Claude Code-credentials-<sha256(cli_config_dir)[:8]>`
+///    against the current user (newer Claude Code on macOS — the default).
+///
+/// On any failure returns a categorised `QuotaError`. Never panics.
 pub fn read_access_token(cli_config_dir: &Path) -> Result<String, QuotaError> {
-    let path = cli_config_dir.join(".credentials.json");
-    let metadata = match std::fs::metadata(&path) {
+    let file_path = cli_config_dir.join(".credentials.json");
+    if file_path.exists() {
+        return read_from_file(&file_path);
+    }
+    read_from_keychain(cli_config_dir)
+}
+
+fn read_from_file(path: &Path) -> Result<String, QuotaError> {
+    let metadata = match std::fs::metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return Err(QuotaError::NoCredentials);
@@ -38,11 +55,68 @@ pub fn read_access_token(cli_config_dir: &Path) -> Result<String, QuotaError> {
     if metadata.len() > MAX_CREDENTIALS_BYTES {
         return Err(QuotaError::Unknown);
     }
-    let raw = match std::fs::read_to_string(&path) {
+    let raw = match std::fs::read_to_string(path) {
         Ok(text) => text,
         Err(_) => return Err(QuotaError::Unknown),
     };
-    let parsed: CredentialsFile = match serde_json::from_str(&raw) {
+    extract_token(&raw)
+}
+
+fn read_from_keychain(cli_config_dir: &Path) -> Result<String, QuotaError> {
+    let service = keychain_service_name(cli_config_dir);
+    // Account name is the current macOS user. Fall back to the empty
+    // string if USER isn't set — `security` will then return whatever
+    // first matching entry it finds, which may be enough.
+    let account = std::env::var("USER").unwrap_or_default();
+
+    let mut command = Command::new("/usr/bin/security");
+    command.arg("find-generic-password").arg("-s").arg(&service);
+    if !account.is_empty() {
+        command.arg("-a").arg(&account);
+    }
+    command.arg("-w");
+
+    let output = match command.output() {
+        Ok(output) => output,
+        Err(_) => return Err(QuotaError::Unknown),
+    };
+
+    if !output.status.success() {
+        // Exit code 44 = errSecItemNotFound. Treat any non-zero as
+        // "no credentials in keychain" — the user hasn't signed in
+        // for this profile, or the entry is under a different account.
+        return Err(QuotaError::NoCredentials);
+    }
+    if output.stdout.len() > MAX_KEYCHAIN_BYTES {
+        return Err(QuotaError::Unknown);
+    }
+
+    let raw = match String::from_utf8(output.stdout) {
+        Ok(text) => text,
+        Err(_) => return Err(QuotaError::Unknown),
+    };
+    extract_token(raw.trim())
+}
+
+/// Pure: compute the macOS Keychain service name Claude Code uses for
+/// a given `CLAUDE_CONFIG_DIR`. The derivation is undocumented Anthropic
+/// internals — see the docblock in `launchers/cli.rs` for context.
+fn keychain_service_name(cli_config_dir: &Path) -> String {
+    let path_str = cli_config_dir.to_string_lossy();
+    let digest = Sha256::digest(path_str.as_bytes());
+    let mut hex = String::with_capacity(8);
+    for byte in digest.iter().take(4) {
+        use std::fmt::Write;
+        let _ = write!(&mut hex, "{byte:02x}");
+    }
+    format!("Claude Code-credentials-{hex}")
+}
+
+/// Pure: parse the credentials JSON blob (same shape on disk and in
+/// keychain) and extract the access token. Empty / missing token →
+/// `NoCredentials`. Malformed JSON → `Unknown`.
+fn extract_token(raw: &str) -> Result<String, QuotaError> {
+    let parsed: CredentialsFile = match serde_json::from_str(raw) {
         Ok(value) => value,
         Err(_) => return Err(QuotaError::Unknown),
     };
@@ -55,6 +129,7 @@ pub fn read_access_token(cli_config_dir: &Path) -> Result<String, QuotaError> {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::PathBuf;
 
     use tempfile::TempDir;
 
@@ -64,15 +139,10 @@ mod tests {
         fs::write(dir.join(".credentials.json"), contents).unwrap();
     }
 
-    #[test]
-    fn missing_file_returns_no_credentials() {
-        let dir = TempDir::new().unwrap();
-        let error = read_access_token(dir.path()).unwrap_err();
-        assert!(matches!(error, QuotaError::NoCredentials));
-    }
+    // -- file-based tests (existing behavior preserved) --
 
     #[test]
-    fn happy_path_returns_token() {
+    fn happy_path_returns_token_from_file() {
         let dir = TempDir::new().unwrap();
         write_creds(
             dir.path(),
@@ -130,5 +200,61 @@ mod tests {
             read_access_token(dir.path()).unwrap_err(),
             QuotaError::Unknown,
         ));
+    }
+
+    // -- keychain derivation (pure function tests) --
+
+    #[test]
+    fn keychain_service_name_uses_first_eight_hex_of_sha256() {
+        // SHA-256("test") = 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+        let dir = PathBuf::from("test");
+        assert_eq!(
+            keychain_service_name(&dir),
+            "Claude Code-credentials-9f86d081"
+        );
+    }
+
+    #[test]
+    fn keychain_service_name_changes_with_path() {
+        let dir_a = PathBuf::from(
+            "/Users/u/Library/Application Support/claude-profiles/profiles/aaa/cli-config",
+        );
+        let dir_b = PathBuf::from(
+            "/Users/u/Library/Application Support/claude-profiles/profiles/bbb/cli-config",
+        );
+        let name_a = keychain_service_name(&dir_a);
+        let name_b = keychain_service_name(&dir_b);
+        assert_ne!(name_a, name_b);
+        assert!(name_a.starts_with("Claude Code-credentials-"));
+        assert!(name_b.starts_with("Claude Code-credentials-"));
+        // Each suffix is exactly 8 hex chars.
+        assert_eq!(name_a.len(), "Claude Code-credentials-".len() + 8);
+    }
+
+    // -- cascade behavior --
+
+    #[test]
+    fn missing_file_cascades_to_keychain_then_no_credentials_when_not_present() {
+        // No credentials file → falls through to keychain → keychain
+        // entry won't exist for this random tempdir path → NoCredentials.
+        // This is an integration check: it runs `security` against a
+        // tempdir-derived service name that won't exist. On non-macOS
+        // platforms `security` isn't available and `Command::new` will
+        // fail with Unknown — accept either NoCredentials or Unknown
+        // here so the test passes in CI on Linux too.
+        let dir = TempDir::new().unwrap();
+        let outcome = read_access_token(dir.path()).unwrap_err();
+        assert!(
+            matches!(outcome, QuotaError::NoCredentials | QuotaError::Unknown),
+            "expected NoCredentials or Unknown, got {outcome:?}",
+        );
+    }
+
+    // -- extract_token (pure) --
+
+    #[test]
+    fn extract_token_parses_keychain_style_blob() {
+        let blob = r#"{"claudeAiOauth":{"accessToken":"sk-ant-from-keychain","refreshToken":"sk-ant-refresh","email":"x@y.z","expiresAt":1234567890000}}"#;
+        assert_eq!(extract_token(blob).unwrap(), "sk-ant-from-keychain");
     }
 }

--- a/apps/claude-profiles/src-tauri/src/usage/credentials.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/credentials.rs
@@ -1,0 +1,135 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::usage::QuotaError;
+
+/// Hard cap on the credentials file size. The real file is tiny
+/// (a few hundred bytes). Anything larger is treated as suspect
+/// and rejected rather than read into memory.
+const MAX_CREDENTIALS_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Deserialize, Default)]
+struct CredentialsFile {
+    #[serde(default)]
+    #[serde(rename = "claudeAiOauth")]
+    claude_ai_oauth: ClaudeOauth,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ClaudeOauth {
+    #[serde(default)]
+    #[serde(rename = "accessToken")]
+    access_token: Option<String>,
+}
+
+/// Reads the access token from `<cli_config_dir>/.credentials.json`.
+/// On any failure (missing file, oversized, unreadable, malformed JSON,
+/// empty token) returns a categorised `QuotaError`. Never panics.
+#[allow(dead_code)]
+pub fn read_access_token(cli_config_dir: &Path) -> Result<String, QuotaError> {
+    let path = cli_config_dir.join(".credentials.json");
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(QuotaError::NoCredentials);
+        }
+        Err(_) => return Err(QuotaError::Unknown),
+    };
+    if metadata.len() > MAX_CREDENTIALS_BYTES {
+        return Err(QuotaError::Unknown);
+    }
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(_) => return Err(QuotaError::Unknown),
+    };
+    let parsed: CredentialsFile = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Err(QuotaError::Unknown),
+    };
+    match parsed.claude_ai_oauth.access_token {
+        Some(token) if !token.trim().is_empty() => Ok(token),
+        _ => Err(QuotaError::NoCredentials),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_creds(dir: &Path, contents: &str) {
+        fs::write(dir.join(".credentials.json"), contents).unwrap();
+    }
+
+    #[test]
+    fn missing_file_returns_no_credentials() {
+        let dir = TempDir::new().unwrap();
+        let error = read_access_token(dir.path()).unwrap_err();
+        assert!(matches!(error, QuotaError::NoCredentials));
+    }
+
+    #[test]
+    fn happy_path_returns_token() {
+        let dir = TempDir::new().unwrap();
+        write_creds(
+            dir.path(),
+            r#"{"claudeAiOauth":{"accessToken":"sk-test-abc"}}"#,
+        );
+        assert_eq!(read_access_token(dir.path()).unwrap(), "sk-test-abc");
+    }
+
+    #[test]
+    fn malformed_json_returns_unknown() {
+        let dir = TempDir::new().unwrap();
+        write_creds(dir.path(), "not json");
+        assert!(matches!(
+            read_access_token(dir.path()).unwrap_err(),
+            QuotaError::Unknown,
+        ));
+    }
+
+    #[test]
+    fn missing_token_field_returns_no_credentials() {
+        let dir = TempDir::new().unwrap();
+        write_creds(dir.path(), r#"{"claudeAiOauth":{}}"#);
+        assert!(matches!(
+            read_access_token(dir.path()).unwrap_err(),
+            QuotaError::NoCredentials,
+        ));
+    }
+
+    #[test]
+    fn empty_token_returns_no_credentials() {
+        let dir = TempDir::new().unwrap();
+        write_creds(dir.path(), r#"{"claudeAiOauth":{"accessToken":"   "}}"#);
+        assert!(matches!(
+            read_access_token(dir.path()).unwrap_err(),
+            QuotaError::NoCredentials,
+        ));
+    }
+
+    #[test]
+    fn unknown_top_level_fields_are_ignored() {
+        let dir = TempDir::new().unwrap();
+        write_creds(
+            dir.path(),
+            r#"{"claudeAiOauth":{"accessToken":"t","extra":42},"other":"hi"}"#,
+        );
+        assert_eq!(read_access_token(dir.path()).unwrap(), "t");
+    }
+
+    #[test]
+    fn oversized_file_returns_unknown() {
+        let dir = TempDir::new().unwrap();
+        let huge = "x".repeat((MAX_CREDENTIALS_BYTES + 1) as usize);
+        write_creds(dir.path(), &huge);
+        assert!(matches!(
+            read_access_token(dir.path()).unwrap_err(),
+            QuotaError::Unknown,
+        ));
+    }
+}

--- a/apps/claude-profiles/src-tauri/src/usage/credentials.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/credentials.rs
@@ -26,7 +26,6 @@ struct ClaudeOauth {
 /// Reads the access token from `<cli_config_dir>/.credentials.json`.
 /// On any failure (missing file, oversized, unreadable, malformed JSON,
 /// empty token) returns a categorised `QuotaError`. Never panics.
-#[allow(dead_code)]
 pub fn read_access_token(cli_config_dir: &Path) -> Result<String, QuotaError> {
     let path = cli_config_dir.join(".credentials.json");
     let metadata = match std::fs::metadata(&path) {

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -31,6 +31,7 @@ pub struct Window {
 pub enum QuotaError {
     NoCredentials,
     Unauthorized,
+    RateLimited,
     Network,
     Unknown,
 }

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod credentials;
 pub(crate) mod quota;
+pub(crate) mod refresh;
 
 use serde::Serialize;
 
@@ -53,14 +54,45 @@ pub async fn build(cli_config_dir: &Path, client: &dyn quota::UsageClient) -> Pr
     }
 }
 
+/// Same as `build`, but on a `QuotaError::Unauthorized` first response we
+/// ask the `refresher` to trigger Claude Code's own OAuth refresh and
+/// then retry the quota fetch once. If the retry also fails the result
+/// surfaces the second error to the user, who then sees the same
+/// "Token refresh needed" message as before — so this strictly improves
+/// the success path without regressing the failure path.
+pub async fn build_with_cli_refresh(
+    cli_config_dir: &Path,
+    client: &dyn quota::UsageClient,
+    refresher: &dyn refresh::CliRefresher,
+) -> ProfileUsage {
+    let first = build(cli_config_dir, client).await;
+    if !matches!(first.quota_error, Some(QuotaError::Unauthorized)) {
+        return first;
+    }
+    refresher.try_refresh(cli_config_dir).await;
+    let retry = quota::fetch_quota(cli_config_dir, client).await;
+    let (quota, quota_error) = match retry {
+        Ok(value) => (Some(value), None),
+        Err(error) => (None, Some(error)),
+    };
+    ProfileUsage {
+        quota,
+        quota_error,
+        fetched_at: Utc::now().to_rfc3339(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
+    use std::sync::Mutex;
 
     use async_trait::async_trait;
     use tempfile::TempDir;
 
     use super::quota::{HttpResponse, UsageClient};
+    use super::refresh::CliRefresher;
     use super::*;
 
     struct AlwaysFailsClient;
@@ -70,6 +102,68 @@ mod tests {
         async fn fetch(&self, _: &str) -> Result<HttpResponse, QuotaError> {
             Err(QuotaError::Network)
         }
+    }
+
+    /// Returns a queued list of responses in order. Once the queue is
+    /// empty, every subsequent call returns Network. Each call records
+    /// the access token it was handed.
+    struct QueuedClient {
+        responses: Mutex<Vec<Result<HttpResponse, QuotaError>>>,
+        calls: Mutex<u32>,
+    }
+
+    impl QueuedClient {
+        fn new(responses: Vec<Result<HttpResponse, QuotaError>>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+                calls: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UsageClient for QueuedClient {
+        async fn fetch(&self, _: &str) -> Result<HttpResponse, QuotaError> {
+            *self.calls.lock().unwrap() += 1;
+            self.responses
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or(Err(QuotaError::Network))
+        }
+    }
+
+    struct RecordingRefresher {
+        calls: Mutex<u32>,
+    }
+
+    impl RecordingRefresher {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CliRefresher for RecordingRefresher {
+        async fn try_refresh(&self, _: &Path) {
+            *self.calls.lock().unwrap() += 1;
+        }
+    }
+
+    fn dir_with_token() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk-test"}}"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    fn body_with_one_window() -> Vec<u8> {
+        br#"{"five_hour":{"utilization":50.0,"resets_at":null}}"#.to_vec()
     }
 
     #[tokio::test]
@@ -94,5 +188,69 @@ mod tests {
             result.quota_error,
             Some(QuotaError::NoCredentials)
         ));
+    }
+
+    // --- build_with_cli_refresh orchestration ---
+
+    #[tokio::test]
+    async fn refresh_is_not_triggered_when_first_fetch_succeeds() {
+        let dir = dir_with_token();
+        let client = QueuedClient::new(vec![Ok(HttpResponse {
+            status: 200,
+            body: body_with_one_window(),
+        })]);
+        let refresher = RecordingRefresher::new();
+        let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
+        assert!(result.quota.is_some());
+        assert!(result.quota_error.is_none());
+        assert_eq!(*refresher.calls.lock().unwrap(), 0);
+        assert_eq!(*client.calls.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_is_not_triggered_for_non_unauthorized_errors() {
+        // Network errors should NOT trigger a refresh — only Unauthorized
+        // is plausibly recoverable by re-running `claude`.
+        let dir = dir_with_token();
+        let client = QueuedClient::new(vec![Err(QuotaError::Network)]);
+        let refresher = RecordingRefresher::new();
+        let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
+        assert!(matches!(result.quota_error, Some(QuotaError::Network)));
+        assert_eq!(*refresher.calls.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn refresh_recovers_on_unauthorized_then_success() {
+        let dir = dir_with_token();
+        // QueuedClient::pop returns from the end, so order responses in
+        // reverse: first call returns Unauthorized, second returns 200.
+        let client = QueuedClient::new(vec![
+            Ok(HttpResponse {
+                status: 200,
+                body: body_with_one_window(),
+            }),
+            Err(QuotaError::Unauthorized),
+        ]);
+        let refresher = RecordingRefresher::new();
+        let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
+        assert!(result.quota.is_some(), "expected recovered quota");
+        assert!(result.quota_error.is_none());
+        assert_eq!(*refresher.calls.lock().unwrap(), 1);
+        assert_eq!(*client.calls.lock().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn refresh_only_runs_once_and_surfaces_second_unauthorized() {
+        let dir = dir_with_token();
+        let client = QueuedClient::new(vec![
+            Err(QuotaError::Unauthorized),
+            Err(QuotaError::Unauthorized),
+        ]);
+        let refresher = RecordingRefresher::new();
+        let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
+        assert!(matches!(result.quota_error, Some(QuotaError::Unauthorized)));
+        assert!(result.quota.is_none());
+        assert_eq!(*refresher.calls.lock().unwrap(), 1);
+        assert_eq!(*client.calls.lock().unwrap(), 2);
     }
 }

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod credentials;
+
 use serde::Serialize;
 
 #[allow(dead_code)]

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod quota;
 
 use serde::Serialize;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileUsage {
@@ -12,7 +11,6 @@ pub struct ProfileUsage {
     pub fetched_at: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuotaUsage {
@@ -21,7 +19,6 @@ pub struct QuotaUsage {
     pub seven_day_sonnet: Option<Window>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Window {
@@ -29,7 +26,6 @@ pub struct Window {
     pub resets_at: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QuotaError {
@@ -37,4 +33,65 @@ pub enum QuotaError {
     Unauthorized,
     Network,
     Unknown,
+}
+
+use std::path::Path;
+
+use chrono::Utc;
+
+/// Fetches the profile's quota and wraps it in a `ProfileUsage`.
+pub async fn build(cli_config_dir: &Path, client: &dyn quota::UsageClient) -> ProfileUsage {
+    let (quota, quota_error) = match quota::fetch_quota(cli_config_dir, client).await {
+        Ok(value) => (Some(value), None),
+        Err(error) => (None, Some(error)),
+    };
+    ProfileUsage {
+        quota,
+        quota_error,
+        fetched_at: Utc::now().to_rfc3339(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    use super::quota::{HttpResponse, UsageClient};
+    use super::*;
+
+    struct AlwaysFailsClient;
+
+    #[async_trait]
+    impl UsageClient for AlwaysFailsClient {
+        async fn fetch(&self, _: &str) -> Result<HttpResponse, QuotaError> {
+            Err(QuotaError::Network)
+        }
+    }
+
+    #[tokio::test]
+    async fn quota_network_failure_surfaces_network_error() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk"}}"#,
+        )
+        .unwrap();
+        let result = build(dir.path(), &AlwaysFailsClient).await;
+        assert!(result.quota.is_none());
+        assert!(matches!(result.quota_error, Some(QuotaError::Network)));
+    }
+
+    #[tokio::test]
+    async fn missing_credentials_returns_nocredentials() {
+        let dir = TempDir::new().unwrap();
+        let client = AlwaysFailsClient;
+        let result = build(dir.path(), &client).await;
+        assert!(matches!(
+            result.quota_error,
+            Some(QuotaError::NoCredentials)
+        ));
+    }
 }

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -1,0 +1,37 @@
+use serde::Serialize;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileUsage {
+    pub quota: Option<QuotaUsage>,
+    pub quota_error: Option<QuotaError>,
+    pub fetched_at: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuotaUsage {
+    pub five_hour: Option<Window>,
+    pub seven_day: Option<Window>,
+    pub seven_day_sonnet: Option<Window>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Window {
+    pub utilization: Option<f32>,
+    pub resets_at: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuotaError {
+    NoCredentials,
+    Unauthorized,
+    Network,
+    Unknown,
+}

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod credentials;
+pub(crate) mod quota;
 
 use serde::Serialize;
 

--- a/apps/claude-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/mod.rs
@@ -38,6 +38,7 @@ pub enum QuotaError {
 }
 
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 
@@ -69,7 +70,14 @@ pub async fn build_with_cli_refresh(
     if !matches!(first.quota_error, Some(QuotaError::Unauthorized)) {
         return first;
     }
+    // Capture the pre-refresh token so we can wait for it to actually
+    // change before retrying. `claude` may exit on stdin-EOF before its
+    // async token-persistence write has fsynced; without this poll a
+    // fast retry would read the stale token and surface Unauthorized
+    // again as if recovery were impossible.
+    let token_before = credentials::read_access_token(cli_config_dir).ok();
     refresher.try_refresh(cli_config_dir).await;
+    wait_for_token_change(cli_config_dir, token_before.as_deref()).await;
     let retry = quota::fetch_quota(cli_config_dir, client).await;
     let (quota, quota_error) = match retry {
         Ok(value) => (Some(value), None),
@@ -82,10 +90,35 @@ pub async fn build_with_cli_refresh(
     }
 }
 
+/// Bound on how long we'll wait for the credentials store to reflect a
+/// new token after the refresher returned. A token-persistence write
+/// from `claude` typically lands in well under 100 ms on warm disks;
+/// 1 s is a generous ceiling for cold/sandboxed cases.
+const TOKEN_CHANGE_DEADLINE: Duration = Duration::from_millis(1000);
+const TOKEN_CHANGE_POLL: Duration = Duration::from_millis(50);
+
+/// Polls the credentials store until the access token differs from
+/// `before`, or until the deadline passes. Returns immediately if the
+/// store can't be read at all (treated as "changed", since the retry
+/// will surface the read failure itself).
+async fn wait_for_token_change(cli_config_dir: &Path, before: Option<&str>) {
+    let deadline = Instant::now() + TOKEN_CHANGE_DEADLINE;
+    loop {
+        let current = credentials::read_access_token(cli_config_dir).ok();
+        if current.as_deref() != before {
+            return;
+        }
+        if Instant::now() >= deadline {
+            return;
+        }
+        tokio::time::sleep(TOKEN_CHANGE_POLL).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::Mutex;
 
     use async_trait::async_trait;
@@ -134,21 +167,25 @@ mod tests {
     }
 
     struct RecordingRefresher {
-        calls: Mutex<u32>,
+        calls: Mutex<Vec<PathBuf>>,
     }
 
     impl RecordingRefresher {
         fn new() -> Self {
             Self {
-                calls: Mutex::new(0),
+                calls: Mutex::new(Vec::new()),
             }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
         }
     }
 
     #[async_trait]
     impl CliRefresher for RecordingRefresher {
-        async fn try_refresh(&self, _: &Path) {
-            *self.calls.lock().unwrap() += 1;
+        async fn try_refresh(&self, dir: &Path) {
+            self.calls.lock().unwrap().push(dir.to_path_buf());
         }
     }
 
@@ -203,7 +240,7 @@ mod tests {
         let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
         assert!(result.quota.is_some());
         assert!(result.quota_error.is_none());
-        assert_eq!(*refresher.calls.lock().unwrap(), 0);
+        assert_eq!(refresher.call_count(), 0);
         assert_eq!(*client.calls.lock().unwrap(), 1);
     }
 
@@ -216,7 +253,7 @@ mod tests {
         let refresher = RecordingRefresher::new();
         let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
         assert!(matches!(result.quota_error, Some(QuotaError::Network)));
-        assert_eq!(*refresher.calls.lock().unwrap(), 0);
+        assert_eq!(refresher.call_count(), 0);
     }
 
     #[tokio::test]
@@ -235,7 +272,7 @@ mod tests {
         let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
         assert!(result.quota.is_some(), "expected recovered quota");
         assert!(result.quota_error.is_none());
-        assert_eq!(*refresher.calls.lock().unwrap(), 1);
+        assert_eq!(refresher.call_count(), 1);
         assert_eq!(*client.calls.lock().unwrap(), 2);
     }
 
@@ -250,7 +287,60 @@ mod tests {
         let result = build_with_cli_refresh(dir.path(), &client, &refresher).await;
         assert!(matches!(result.quota_error, Some(QuotaError::Unauthorized)));
         assert!(result.quota.is_none());
-        assert_eq!(*refresher.calls.lock().unwrap(), 1);
+        assert_eq!(refresher.call_count(), 1);
         assert_eq!(*client.calls.lock().unwrap(), 2);
+    }
+
+    // --- wait_for_token_change ---
+
+    #[tokio::test]
+    async fn wait_for_token_change_returns_quickly_when_token_changes() {
+        let dir = dir_with_token();
+        let path = dir.path().to_path_buf();
+        let writer = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            fs::write(
+                path.join(".credentials.json"),
+                r#"{"claudeAiOauth":{"accessToken":"sk-fresh"}}"#,
+            )
+            .unwrap();
+        });
+        let started = Instant::now();
+        wait_for_token_change(dir.path(), Some("sk-test")).await;
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "expected return shortly after token changed, took {:?}",
+            started.elapsed(),
+        );
+        writer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_for_token_change_returns_at_deadline_when_unchanged() {
+        let dir = dir_with_token();
+        let started = Instant::now();
+        wait_for_token_change(dir.path(), Some("sk-test")).await;
+        let elapsed = started.elapsed();
+        // Should have waited approximately TOKEN_CHANGE_DEADLINE (1 s).
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "expected ≥ ~900ms wait, got {elapsed:?}",
+        );
+        assert!(
+            elapsed < Duration::from_millis(1500),
+            "expected ≤ ~1500ms wait, got {elapsed:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_token_change_returns_when_credentials_disappear() {
+        // If the credentials file vanishes between calls, treat that as
+        // "changed" — read_access_token returning Err means `current` is
+        // None which differs from a Some(_) baseline, so we exit.
+        let dir = dir_with_token();
+        fs::remove_file(dir.path().join(".credentials.json")).unwrap();
+        let started = Instant::now();
+        wait_for_token_change(dir.path(), Some("sk-test")).await;
+        assert!(started.elapsed() < Duration::from_millis(200));
     }
 }

--- a/apps/claude-profiles/src-tauri/src/usage/quota.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/quota.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::path::Path;
 use std::time::Duration;
 

--- a/apps/claude-profiles/src-tauri/src/usage/quota.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/quota.rs
@@ -44,7 +44,7 @@ impl ReqwestUsageClient {
 #[async_trait]
 impl UsageClient for ReqwestUsageClient {
     async fn fetch(&self, access_token: &str) -> Result<HttpResponse, QuotaError> {
-        let response = self
+        let mut response = self
             .client
             .get(USAGE_URL)
             .bearer_auth(access_token)
@@ -55,14 +55,33 @@ impl UsageClient for ReqwestUsageClient {
             .await
             .map_err(|_| QuotaError::Network)?;
         let status = response.status().as_u16();
-        let bytes = response.bytes().await.map_err(|_| QuotaError::Network)?;
-        if bytes.len() > MAX_BODY_BYTES {
-            return Err(QuotaError::Unknown);
+
+        // Pre-flight cap: if the server advertises a body larger than
+        // we're willing to read, refuse before buffering a single byte.
+        // The real response is well under 1 KiB so this only ever fires
+        // on a misconfigured/hostile endpoint.
+        if let Some(content_length) = response.content_length() {
+            if content_length > MAX_BODY_BYTES as u64 {
+                return Err(QuotaError::Unknown);
+            }
         }
-        Ok(HttpResponse {
-            status,
-            body: bytes.to_vec(),
-        })
+
+        // Streamed read with a running cap, so a server that omits
+        // Content-Length (or lies about it) still can't OOM us.
+        let mut body: Vec<u8> = Vec::new();
+        loop {
+            match response.chunk().await {
+                Ok(Some(chunk)) => {
+                    if body.len().saturating_add(chunk.len()) > MAX_BODY_BYTES {
+                        return Err(QuotaError::Unknown);
+                    }
+                    body.extend_from_slice(&chunk);
+                }
+                Ok(None) => break,
+                Err(_) => return Err(QuotaError::Network),
+            }
+        }
+        Ok(HttpResponse { status, body })
     }
 }
 
@@ -80,7 +99,12 @@ pub async fn fetch_quota(
         401 | 403 => Err(QuotaError::Unauthorized),
         429 => Err(QuotaError::RateLimited),
         500..=599 => Err(QuotaError::Network),
-        _ => Err(QuotaError::Network),
+        // Other 4xx (400 bad request, 404 endpoint moved, 410 gone, …)
+        // are client-side / contract-shape problems that won't resolve
+        // by retrying — surface them as `Unknown` so the UI shows
+        // "Couldn't load usage stats" rather than "check your connection".
+        400..=499 => Err(QuotaError::Unknown),
+        _ => Err(QuotaError::Unknown),
     }
 }
 
@@ -246,6 +270,35 @@ mod tests {
         assert!(matches!(
             fetch_quota(dir.path(), &client).await.unwrap_err(),
             QuotaError::RateLimited,
+        ));
+    }
+
+    #[tokio::test]
+    async fn bad_request_maps_to_unknown_not_network() {
+        // 400 from a deprecated beta header or schema drift should
+        // surface as Unknown so the UI doesn't show "check your
+        // connection" for what is actually a permanent contract break.
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 400,
+            body: b"".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Unknown,
+        ));
+    }
+
+    #[tokio::test]
+    async fn not_found_maps_to_unknown_not_network() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 404,
+            body: b"".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Unknown,
         ));
     }
 

--- a/apps/claude-profiles/src-tauri/src/usage/quota.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/quota.rs
@@ -75,14 +75,11 @@ pub async fn fetch_quota(
 ) -> Result<QuotaUsage, QuotaError> {
     let token = read_access_token(cli_config_dir)?;
     let response = client.fetch(&token).await?;
-    // 429 and 5xx are explicitly split out from the catch-all even
-    // though both currently map to Network — they represent a
-    // distinct "transient, retry will probably help" category that
-    // may grow its own variant later (e.g. RateLimited for backoff).
     match response.status {
         200 => parse_body(&response.body),
         401 | 403 => Err(QuotaError::Unauthorized),
-        429 | 500..=599 => Err(QuotaError::Network),
+        429 => Err(QuotaError::RateLimited),
+        500..=599 => Err(QuotaError::Network),
         _ => Err(QuotaError::Network),
     }
 }
@@ -240,7 +237,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rate_limit_maps_to_network() {
+    async fn rate_limit_maps_to_rate_limited() {
         let dir = dir_with_token();
         let client = StubClient {
             status: 429,
@@ -248,7 +245,7 @@ mod tests {
         };
         assert!(matches!(
             fetch_quota(dir.path(), &client).await.unwrap_err(),
-            QuotaError::Network,
+            QuotaError::RateLimited,
         ));
     }
 

--- a/apps/claude-profiles/src-tauri/src/usage/quota.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/quota.rs
@@ -103,9 +103,14 @@ fn parse_body(body: &[u8]) -> Result<QuotaUsage, QuotaError> {
     Ok(usage)
 }
 
+/// Anthropic returns `utilization` as a percentage on a 0..=100 scale
+/// (e.g. `42.0` means 42%). We accept any finite non-negative value
+/// without an upper clamp — values above 100 are unusual but legitimate
+/// (over-limit) and we'd rather show "105%" than drop the data. The
+/// UI is responsible for capping the visual bar fill at 100%.
 fn into_window(raw: ApiWindow) -> Window {
     let utilization = match raw.utilization {
-        Some(value) if value.is_finite() && (0.0..=1.0).contains(&value) => Some(value),
+        Some(value) if value.is_finite() && value >= 0.0 => Some(value),
         _ => None,
     };
     Window {
@@ -179,17 +184,19 @@ mod tests {
     #[tokio::test]
     async fn happy_path_parses_all_windows() {
         let dir = dir_with_token();
+        // Utilization is a percentage on the 0..=100 scale, matching
+        // Anthropic's actual response (verified against the live endpoint).
         let body = br#"{
-            "five_hour": {"utilization": 0.63, "resets_at": "2099-01-01T00:00:00Z"},
-            "seven_day": {"utilization": 0.21, "resets_at": null},
-            "seven_day_sonnet": {"utilization": 0.08, "resets_at": null}
+            "five_hour": {"utilization": 63.0, "resets_at": "2099-01-01T00:00:00Z"},
+            "seven_day": {"utilization": 21.0, "resets_at": null},
+            "seven_day_sonnet": {"utilization": 8.0, "resets_at": null}
         }"#;
         let client = StubClient {
             status: 200,
             body: body.to_vec(),
         };
         let usage = fetch_quota(dir.path(), &client).await.unwrap();
-        assert!((usage.five_hour.unwrap().utilization.unwrap() - 0.63).abs() < 1e-4);
+        assert!((usage.five_hour.unwrap().utilization.unwrap() - 63.0).abs() < 1e-4);
         assert_eq!(usage.seven_day.unwrap().resets_at, None);
     }
 
@@ -311,12 +318,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn out_of_range_or_nan_utilization_is_dropped() {
+    async fn negative_or_null_utilization_is_dropped() {
         let dir = dir_with_token();
+        // Only negative and explicit null values are dropped now —
+        // values above 100 are allowed since Anthropic can return
+        // over-limit percentages (e.g. 105% when overused).
         let body = br#"{
-            "five_hour": {"utilization": 1.7},
-            "seven_day": {"utilization": -0.2},
-            "seven_day_sonnet": {"utilization": null}
+            "five_hour": {"utilization": -0.5},
+            "seven_day": {"utilization": null},
+            "seven_day_sonnet": {"utilization": -10.0}
         }"#;
         let client = StubClient {
             status: 200,
@@ -326,6 +336,18 @@ mod tests {
         assert!(usage.five_hour.unwrap().utilization.is_none());
         assert!(usage.seven_day.unwrap().utilization.is_none());
         assert!(usage.seven_day_sonnet.unwrap().utilization.is_none());
+    }
+
+    #[tokio::test]
+    async fn over_one_hundred_utilization_is_preserved() {
+        let dir = dir_with_token();
+        let body = br#"{"five_hour":{"utilization":105.0,"resets_at":null}}"#;
+        let client = StubClient {
+            status: 200,
+            body: body.to_vec(),
+        };
+        let usage = fetch_quota(dir.path(), &client).await.unwrap();
+        assert_eq!(usage.five_hour.unwrap().utilization, Some(105.0));
     }
 
     #[tokio::test]

--- a/apps/claude-profiles/src-tauri/src/usage/quota.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/quota.rs
@@ -1,0 +1,360 @@
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::usage::credentials::read_access_token;
+use crate::usage::{QuotaError, QuotaUsage, Window};
+
+const USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+const BETA_HEADER: &str = "oauth-2025-04-20";
+const REQUEST_TIMEOUT_SECS: u64 = 8;
+/// Hard cap on response body size. The real response is well under 1 KiB.
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+pub struct HttpResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+}
+
+#[async_trait]
+pub trait UsageClient: Send + Sync {
+    async fn fetch(&self, access_token: &str) -> Result<HttpResponse, QuotaError>;
+}
+
+/// Production client using `reqwest`. Tests inject a stub instead.
+/// The inner `reqwest::Client` is built once so the connection pool
+/// is reused across the 5-minute refresh ticks.
+pub struct ReqwestUsageClient {
+    client: reqwest::Client,
+    user_agent: String,
+}
+
+impl ReqwestUsageClient {
+    pub fn new(user_agent: String) -> Result<Self, QuotaError> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .map_err(|_| QuotaError::Network)?;
+        Ok(Self { client, user_agent })
+    }
+}
+
+#[async_trait]
+impl UsageClient for ReqwestUsageClient {
+    async fn fetch(&self, access_token: &str) -> Result<HttpResponse, QuotaError> {
+        let response = self
+            .client
+            .get(USAGE_URL)
+            .bearer_auth(access_token)
+            .header("anthropic-beta", BETA_HEADER)
+            .header("user-agent", &self.user_agent)
+            .header("accept", "application/json")
+            .send()
+            .await
+            .map_err(|_| QuotaError::Network)?;
+        let status = response.status().as_u16();
+        let bytes = response.bytes().await.map_err(|_| QuotaError::Network)?;
+        if bytes.len() > MAX_BODY_BYTES {
+            return Err(QuotaError::Unknown);
+        }
+        Ok(HttpResponse {
+            status,
+            body: bytes.to_vec(),
+        })
+    }
+}
+
+/// Fetches and parses the quota for the profile at `cli_config_dir`,
+/// using the provided HTTP client. Returns `Ok(QuotaUsage)` only on
+/// 200 with at least one parseable window.
+pub async fn fetch_quota(
+    cli_config_dir: &Path,
+    client: &dyn UsageClient,
+) -> Result<QuotaUsage, QuotaError> {
+    let token = read_access_token(cli_config_dir)?;
+    let response = client.fetch(&token).await?;
+    // 429 and 5xx are explicitly split out from the catch-all even
+    // though both currently map to Network — they represent a
+    // distinct "transient, retry will probably help" category that
+    // may grow its own variant later (e.g. RateLimited for backoff).
+    match response.status {
+        200 => parse_body(&response.body),
+        401 | 403 => Err(QuotaError::Unauthorized),
+        429 | 500..=599 => Err(QuotaError::Network),
+        _ => Err(QuotaError::Network),
+    }
+}
+
+fn parse_body(body: &[u8]) -> Result<QuotaUsage, QuotaError> {
+    let parsed: ApiResponse = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(_) => return Err(QuotaError::Unknown),
+    };
+    let usage = QuotaUsage {
+        five_hour: parsed.five_hour.map(into_window),
+        seven_day: parsed.seven_day.map(into_window),
+        seven_day_sonnet: parsed.seven_day_sonnet.map(into_window),
+    };
+    if usage.five_hour.is_none() && usage.seven_day.is_none() && usage.seven_day_sonnet.is_none() {
+        return Err(QuotaError::Unknown);
+    }
+    Ok(usage)
+}
+
+fn into_window(raw: ApiWindow) -> Window {
+    let utilization = match raw.utilization {
+        Some(value) if value.is_finite() && (0.0..=1.0).contains(&value) => Some(value),
+        _ => None,
+    };
+    Window {
+        utilization,
+        resets_at: raw.resets_at,
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ApiResponse {
+    #[serde(default)]
+    five_hour: Option<ApiWindow>,
+    #[serde(default)]
+    seven_day: Option<ApiWindow>,
+    #[serde(default)]
+    seven_day_sonnet: Option<ApiWindow>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ApiWindow {
+    #[serde(default)]
+    utilization: Option<f32>,
+    #[serde(default)]
+    resets_at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    struct StubClient {
+        status: u16,
+        body: Vec<u8>,
+    }
+
+    #[async_trait]
+    impl UsageClient for StubClient {
+        async fn fetch(&self, _: &str) -> Result<HttpResponse, QuotaError> {
+            Ok(HttpResponse {
+                status: self.status,
+                body: self.body.clone(),
+            })
+        }
+    }
+
+    struct ErroringClient {
+        error: QuotaError,
+    }
+
+    #[async_trait]
+    impl UsageClient for ErroringClient {
+        async fn fetch(&self, _: &str) -> Result<HttpResponse, QuotaError> {
+            Err(self.error)
+        }
+    }
+
+    fn dir_with_token() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk-test"}}"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn happy_path_parses_all_windows() {
+        let dir = dir_with_token();
+        let body = br#"{
+            "five_hour": {"utilization": 0.63, "resets_at": "2099-01-01T00:00:00Z"},
+            "seven_day": {"utilization": 0.21, "resets_at": null},
+            "seven_day_sonnet": {"utilization": 0.08, "resets_at": null}
+        }"#;
+        let client = StubClient {
+            status: 200,
+            body: body.to_vec(),
+        };
+        let usage = fetch_quota(dir.path(), &client).await.unwrap();
+        assert!((usage.five_hour.unwrap().utilization.unwrap() - 0.63).abs() < 1e-4);
+        assert_eq!(usage.seven_day.unwrap().resets_at, None);
+    }
+
+    #[tokio::test]
+    async fn no_credentials_returns_no_credentials() {
+        let dir = TempDir::new().unwrap();
+        let client = StubClient {
+            status: 200,
+            body: b"{}".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::NoCredentials,
+        ));
+    }
+
+    #[tokio::test]
+    async fn unauthorized_status_maps_to_unauthorized() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 401,
+            body: b"{}".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Unauthorized,
+        ));
+    }
+
+    #[tokio::test]
+    async fn forbidden_status_maps_to_unauthorized() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 403,
+            body: b"{}".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Unauthorized,
+        ));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_maps_to_network() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 429,
+            body: b"".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Network,
+        ));
+    }
+
+    #[tokio::test]
+    async fn server_error_maps_to_network() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 503,
+            body: b"".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Network,
+        ));
+    }
+
+    #[tokio::test]
+    async fn transport_failure_maps_to_network() {
+        let dir = dir_with_token();
+        let client = ErroringClient {
+            error: QuotaError::Network,
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Network,
+        ));
+    }
+
+    #[tokio::test]
+    async fn garbage_body_maps_to_unknown() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 200,
+            body: b"not json".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Unknown,
+        ));
+    }
+
+    #[tokio::test]
+    async fn empty_object_with_no_windows_maps_to_unknown() {
+        let dir = dir_with_token();
+        let client = StubClient {
+            status: 200,
+            body: b"{}".to_vec(),
+        };
+        assert!(matches!(
+            fetch_quota(dir.path(), &client).await.unwrap_err(),
+            QuotaError::Unknown,
+        ));
+    }
+
+    #[tokio::test]
+    async fn partial_response_keeps_present_windows() {
+        let dir = dir_with_token();
+        let body = br#"{"five_hour":{"utilization":0.5,"resets_at":"x"}}"#;
+        let client = StubClient {
+            status: 200,
+            body: body.to_vec(),
+        };
+        let usage = fetch_quota(dir.path(), &client).await.unwrap();
+        assert!(usage.five_hour.is_some());
+        assert!(usage.seven_day.is_none());
+        assert!(usage.seven_day_sonnet.is_none());
+    }
+
+    #[tokio::test]
+    async fn out_of_range_or_nan_utilization_is_dropped() {
+        let dir = dir_with_token();
+        let body = br#"{
+            "five_hour": {"utilization": 1.7},
+            "seven_day": {"utilization": -0.2},
+            "seven_day_sonnet": {"utilization": null}
+        }"#;
+        let client = StubClient {
+            status: 200,
+            body: body.to_vec(),
+        };
+        let usage = fetch_quota(dir.path(), &client).await.unwrap();
+        assert!(usage.five_hour.unwrap().utilization.is_none());
+        assert!(usage.seven_day.unwrap().utilization.is_none());
+        assert!(usage.seven_day_sonnet.unwrap().utilization.is_none());
+    }
+
+    #[tokio::test]
+    async fn zero_utilization_is_preserved() {
+        let dir = dir_with_token();
+        let body = br#"{"five_hour":{"utilization":0.0,"resets_at":null}}"#;
+        let client = StubClient {
+            status: 200,
+            body: body.to_vec(),
+        };
+        let usage = fetch_quota(dir.path(), &client).await.unwrap();
+        assert_eq!(usage.five_hour.unwrap().utilization, Some(0.0));
+    }
+
+    #[tokio::test]
+    async fn unknown_top_level_fields_are_ignored() {
+        let dir = dir_with_token();
+        let body = br#"{
+            "five_hour": {"utilization": 0.1},
+            "future_window": {"utilization": 0.9},
+            "extra": "hi"
+        }"#;
+        let client = StubClient {
+            status: 200,
+            body: body.to_vec(),
+        };
+        let usage = fetch_quota(dir.path(), &client).await.unwrap();
+        assert!(usage.five_hour.is_some());
+    }
+}

--- a/apps/claude-profiles/src-tauri/src/usage/refresh.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/refresh.rs
@@ -1,0 +1,178 @@
+//! Triggers Claude Code's built-in OAuth token refresh by spawning the
+//! `claude` binary as a subprocess with the profile's `CLAUDE_CONFIG_DIR`
+//! set and stdin closed.
+//!
+//! ## Why we delegate to Claude Code instead of refreshing ourselves
+//!
+//! The credentials blob stored by Claude Code includes a long-lived
+//! `refreshToken` alongside the short-lived `accessToken`. Refreshing the
+//! access token requires POSTing to Anthropic's OAuth token endpoint with
+//! the refresh token and a `client_id` — neither of which is publicly
+//! documented. Reverse-engineering them would couple us to undocumented
+//! internals that can change without notice. Delegating to Claude Code
+//! itself sidesteps that entire problem: when invoked it silently
+//! refreshes its own token using its own knowledge of those endpoints.
+//!
+//! ## How the spawn works
+//!
+//! `claude < /dev/null > /dev/null 2>&1` exits cleanly within a few
+//! hundred milliseconds — the REPL detects EOF on stdin during its
+//! startup pass and exits before showing a prompt. The auth refresh
+//! happens early in that startup pass, before stdin is read. We bound
+//! the wait at 8s (matching the quota fetch timeout) and `kill_on_drop`
+//! ensures the child is reaped if our timeout fires.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+/// How long we'll wait for the spawned `claude` to finish refreshing
+/// its token before giving up. Matches the quota fetch timeout.
+const REFRESH_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[async_trait]
+pub trait CliRefresher: Send + Sync {
+    /// Best-effort: trigger a token refresh for the given profile config dir.
+    /// Always returns — success is verified by the caller re-issuing the
+    /// quota fetch, never by inspecting any return value here.
+    async fn try_refresh(&self, cli_config_dir: &Path);
+}
+
+/// Production refresher. Spawns the real `claude` binary.
+pub struct ClaudeCliRefresher;
+
+#[async_trait]
+impl CliRefresher for ClaudeCliRefresher {
+    async fn try_refresh(&self, cli_config_dir: &Path) {
+        let Some(binary) = find_claude_binary() else {
+            return;
+        };
+        let mut command = tokio::process::Command::new(&binary);
+        command
+            .env("CLAUDE_CONFIG_DIR", cli_config_dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true);
+        let Ok(mut child) = command.spawn() else {
+            return;
+        };
+        // We don't care about the exit status. If the timeout fires, the
+        // future is dropped and `kill_on_drop` reaps the child.
+        let _ = tokio::time::timeout(REFRESH_TIMEOUT, child.wait()).await;
+    }
+}
+
+/// Locate the `claude` binary. Tauri apps launched from Finder/Dock have
+/// a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes common
+/// install locations, so PATH lookup alone is unreliable. We try PATH
+/// first, then fall back to the standard install locations on macOS.
+fn find_claude_binary() -> Option<PathBuf> {
+    let path_env = std::env::var_os("PATH");
+    let home = dirs::home_dir();
+    find_claude_binary_in(path_env.as_deref(), home.as_deref())
+}
+
+/// Pure variant used by both `find_claude_binary` and tests. Takes the
+/// raw `PATH` env value and the user's home dir as explicit inputs.
+fn find_claude_binary_in(
+    path_env: Option<&std::ffi::OsStr>,
+    home: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(found) = path_env.and_then(|path| find_in_path("claude", path)) {
+        return Some(found);
+    }
+    let mut fallbacks: Vec<PathBuf> = Vec::new();
+    if let Some(home) = home {
+        fallbacks.push(home.join(".local").join("bin").join("claude"));
+        fallbacks.push(home.join(".claude").join("local").join("claude"));
+    }
+    fallbacks.push(PathBuf::from("/opt/homebrew/bin/claude"));
+    fallbacks.push(PathBuf::from("/usr/local/bin/claude"));
+    fallbacks.into_iter().find(|candidate| candidate.is_file())
+}
+
+/// Pure: walk a PATH-style env value looking for the first entry that
+/// contains an executable file named `name`.
+fn find_in_path(name: &str, path_env: &std::ffi::OsStr) -> Option<PathBuf> {
+    for dir in std::env::split_paths(path_env) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn make_executable(path: &Path) {
+        fs::write(path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn find_in_path_returns_first_match() {
+        let first = TempDir::new().unwrap();
+        let second = TempDir::new().unwrap();
+        make_executable(&first.path().join("dummy-binary"));
+        make_executable(&second.path().join("dummy-binary"));
+
+        let combined = std::env::join_paths([first.path(), second.path()]).unwrap();
+        let found = find_in_path("dummy-binary", &combined);
+        assert_eq!(found.unwrap(), first.path().join("dummy-binary"));
+    }
+
+    #[test]
+    fn find_in_path_returns_none_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let path_env = std::ffi::OsString::from(dir.path());
+        let result = find_in_path("definitely-not-here-9f86d081", &path_env);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_claude_binary_in_prefers_path_over_fallbacks() {
+        let path_dir = TempDir::new().unwrap();
+        make_executable(&path_dir.path().join("claude"));
+        let fake_home = TempDir::new().unwrap();
+        // Also create a fallback so we can prove PATH wins.
+        let fallback_dir = fake_home.path().join(".local").join("bin");
+        fs::create_dir_all(&fallback_dir).unwrap();
+        make_executable(&fallback_dir.join("claude"));
+
+        let path_env = std::ffi::OsString::from(path_dir.path());
+        let found = find_claude_binary_in(Some(&path_env), Some(fake_home.path()));
+        assert_eq!(found.unwrap(), path_dir.path().join("claude"));
+    }
+
+    #[test]
+    fn find_claude_binary_in_falls_back_to_home_when_path_misses() {
+        let fake_home = TempDir::new().unwrap();
+        let fallback_dir = fake_home.path().join(".local").join("bin");
+        fs::create_dir_all(&fallback_dir).unwrap();
+        let expected = fallback_dir.join("claude");
+        make_executable(&expected);
+
+        // Empty PATH-like input: a tempdir with no `claude` in it.
+        let empty_path_dir = TempDir::new().unwrap();
+        let path_env = std::ffi::OsString::from(empty_path_dir.path());
+        let found = find_claude_binary_in(Some(&path_env), Some(fake_home.path()));
+        assert_eq!(found.unwrap(), expected);
+    }
+
+    // No "returns None when nothing found" test — `/opt/homebrew/bin/claude`
+    // and `/usr/local/bin/claude` are real paths that may exist on the
+    // test runner and we don't want a system-state-dependent flake.
+}

--- a/apps/claude-profiles/src-tauri/src/usage/refresh.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/refresh.rs
@@ -89,6 +89,10 @@ fn find_claude_binary_in(
         fallbacks.push(home.join(".local").join("bin").join("claude"));
         fallbacks.push(home.join(".claude").join("local").join("claude"));
     }
+    // `/opt/homebrew/bin` is Apple Silicon Homebrew specifically — only
+    // probe it on macOS. `/usr/local/bin` is a common install location
+    // on both macOS (Intel Homebrew) and Linux, so we keep it everywhere.
+    #[cfg(target_os = "macos")]
     fallbacks.push(PathBuf::from("/opt/homebrew/bin/claude"));
     fallbacks.push(PathBuf::from("/usr/local/bin/claude"));
     fallbacks.into_iter().find(|candidate| candidate.is_file())

--- a/apps/claude-profiles/src-tauri/src/usage/refresh.rs
+++ b/apps/claude-profiles/src-tauri/src/usage/refresh.rs
@@ -22,15 +22,24 @@
 //! the wait at 8s (matching the quota fetch timeout) and `kill_on_drop`
 //! ensures the child is reaped if our timeout fires.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::time::Duration;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use tokio::sync::Mutex as TokioMutex;
 
 /// How long we'll wait for the spawned `claude` to finish refreshing
 /// its token before giving up. Matches the quota fetch timeout.
 const REFRESH_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// After a refresh attempt completes, skip further attempts for the
+/// same profile inside this window. Without this, a profile whose
+/// refresh token is permanently invalid would spawn `claude` on every
+/// 5-minute refetch tick — many subprocesses per workday for no gain.
+const REFRESH_BACKOFF: Duration = Duration::from_secs(60);
 
 #[async_trait]
 pub trait CliRefresher: Send + Sync {
@@ -40,29 +49,102 @@ pub trait CliRefresher: Send + Sync {
     async fn try_refresh(&self, cli_config_dir: &Path);
 }
 
-/// Production refresher. Spawns the real `claude` binary.
-pub struct ClaudeCliRefresher;
+/// Tracks per-profile refresh state across calls so:
+///   - two concurrent refreshes on the same profile serialise (the
+///     second waits for the first instead of racing the same refresh
+///     token through Anthropic's OAuth endpoint twice in parallel);
+///   - a profile that just attempted a refresh is skipped for
+///     `REFRESH_BACKOFF` so a permanently-broken profile doesn't spawn
+///     `claude` on every refetch tick.
+#[derive(Default)]
+struct RefreshRegistry {
+    inflight: StdMutex<HashMap<PathBuf, Arc<TokioMutex<()>>>>,
+    last_attempt: StdMutex<HashMap<PathBuf, Instant>>,
+}
+
+impl RefreshRegistry {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the async mutex for `key`, creating it if needed. The
+    /// caller awaits `.lock()` on the returned mutex; concurrent calls
+    /// on the same `key` serialise on it.
+    fn slot(&self, key: &Path) -> Arc<TokioMutex<()>> {
+        let mut map = self.inflight.lock().unwrap();
+        map.entry(key.to_path_buf())
+            .or_insert_with(|| Arc::new(TokioMutex::new(())))
+            .clone()
+    }
+
+    fn should_skip(&self, key: &Path) -> bool {
+        let map = self.last_attempt.lock().unwrap();
+        match map.get(key) {
+            Some(at) => at.elapsed() < REFRESH_BACKOFF,
+            None => false,
+        }
+    }
+
+    fn mark_attempted(&self, key: &Path) {
+        let mut map = self.last_attempt.lock().unwrap();
+        map.insert(key.to_path_buf(), Instant::now());
+    }
+}
+
+/// Production refresher. Spawns the real `claude` binary, with a
+/// per-profile mutex + 60 s backoff so it never races itself or
+/// hammers a permanently-broken profile.
+pub struct ClaudeCliRefresher {
+    registry: RefreshRegistry,
+}
+
+impl ClaudeCliRefresher {
+    pub fn new() -> Self {
+        Self {
+            registry: RefreshRegistry::new(),
+        }
+    }
+}
+
+impl Default for ClaudeCliRefresher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl CliRefresher for ClaudeCliRefresher {
     async fn try_refresh(&self, cli_config_dir: &Path) {
-        let Some(binary) = find_claude_binary() else {
+        let slot = self.registry.slot(cli_config_dir);
+        let _guard = slot.lock().await;
+        // Re-check the backoff *after* acquiring the lock — another task
+        // may have just finished a refresh on this profile while we were
+        // waiting; if so we want to inherit its result, not re-spawn.
+        if self.registry.should_skip(cli_config_dir) {
             return;
-        };
-        let mut command = tokio::process::Command::new(&binary);
-        command
-            .env("CLAUDE_CONFIG_DIR", cli_config_dir)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .kill_on_drop(true);
-        let Ok(mut child) = command.spawn() else {
-            return;
-        };
-        // We don't care about the exit status. If the timeout fires, the
-        // future is dropped and `kill_on_drop` reaps the child.
-        let _ = tokio::time::timeout(REFRESH_TIMEOUT, child.wait()).await;
+        }
+        self.registry.mark_attempted(cli_config_dir);
+        spawn_claude(cli_config_dir).await;
     }
+}
+
+async fn spawn_claude(cli_config_dir: &Path) {
+    let Some(binary) = find_claude_binary() else {
+        return;
+    };
+    let mut command = tokio::process::Command::new(&binary);
+    command
+        .env("CLAUDE_CONFIG_DIR", cli_config_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let Ok(mut child) = command.spawn() else {
+        return;
+    };
+    // We don't care about the exit status. If the timeout fires, the
+    // future is dropped and `kill_on_drop` reaps the child.
+    let _ = tokio::time::timeout(REFRESH_TIMEOUT, child.wait()).await;
 }
 
 /// Locate the `claude` binary. Tauri apps launched from Finder/Dock have
@@ -179,4 +261,90 @@ mod tests {
     // No "returns None when nothing found" test — `/opt/homebrew/bin/claude`
     // and `/usr/local/bin/claude` are real paths that may exist on the
     // test runner and we don't want a system-state-dependent flake.
+
+    // --- RefreshRegistry primitives ---
+
+    #[test]
+    fn registry_does_not_skip_first_attempt() {
+        let registry = RefreshRegistry::new();
+        let dir = PathBuf::from("/tmp/test-prof-fresh");
+        assert!(!registry.should_skip(&dir));
+    }
+
+    #[test]
+    fn registry_skips_within_backoff_window() {
+        let registry = RefreshRegistry::new();
+        let dir = PathBuf::from("/tmp/test-prof-recent");
+        registry.mark_attempted(&dir);
+        assert!(registry.should_skip(&dir));
+    }
+
+    #[test]
+    fn registry_tracks_per_profile_independently() {
+        let registry = RefreshRegistry::new();
+        let dir_a = PathBuf::from("/tmp/test-prof-a");
+        let dir_b = PathBuf::from("/tmp/test-prof-b");
+        registry.mark_attempted(&dir_a);
+        assert!(registry.should_skip(&dir_a));
+        assert!(!registry.should_skip(&dir_b));
+    }
+
+    #[tokio::test]
+    async fn registry_slot_serialises_same_profile() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let registry = Arc::new(RefreshRegistry::new());
+        let counter = Arc::new(AtomicU32::new(0));
+        let max_observed = Arc::new(AtomicU32::new(0));
+        let dir = PathBuf::from("/tmp/test-prof-serialise");
+
+        let mut tasks = Vec::new();
+        for _ in 0..5 {
+            let registry = registry.clone();
+            let counter = counter.clone();
+            let max_observed = max_observed.clone();
+            let dir = dir.clone();
+            tasks.push(tokio::spawn(async move {
+                let slot = registry.slot(&dir);
+                let _guard = slot.lock().await;
+                let inflight = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                max_observed.fetch_max(inflight, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                counter.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        // At most one holder of the slot lock at any time.
+        assert_eq!(max_observed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn registry_slot_does_not_serialise_different_profiles() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let registry = Arc::new(RefreshRegistry::new());
+        let counter = Arc::new(AtomicU32::new(0));
+        let max_observed = Arc::new(AtomicU32::new(0));
+
+        let mut tasks = Vec::new();
+        for index in 0..4 {
+            let registry = registry.clone();
+            let counter = counter.clone();
+            let max_observed = max_observed.clone();
+            let dir = PathBuf::from(format!("/tmp/test-prof-parallel-{index}"));
+            tasks.push(tokio::spawn(async move {
+                let slot = registry.slot(&dir);
+                let _guard = slot.lock().await;
+                let inflight = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                max_observed.fetch_max(inflight, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                counter.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        // Different profiles can run concurrently, so we should see >1.
+        assert!(max_observed.load(Ordering::SeqCst) > 1);
+    }
 }

--- a/apps/claude-profiles/src/app.tsx
+++ b/apps/claude-profiles/src/app.tsx
@@ -16,7 +16,7 @@ import { ChooseStartDialog } from '@/features/migration/components/choose-start-
 import { MigrationDialog } from '@/features/migration/components/migration-dialog'
 import { PathSetupBanner } from '@/features/onboarding/components/path-setup-banner'
 import { WelcomeDialog } from '@/features/onboarding/components/welcome-dialog'
-import { useProfileUsage } from '@/features/profiles/api/use-profile-usage'
+import { useProfileLastUsed } from '@/features/profiles/api/use-profile-last-used'
 import { useProfiles } from '@/features/profiles/api/use-profiles'
 import { CreateProfileDialog } from '@/features/profiles/components/create-profile-dialog'
 import { DeleteProfileDialog } from '@/features/profiles/components/delete-profile-dialog'
@@ -92,7 +92,7 @@ function AppContent() {
   const migration = useMigration()
   const appState = useAppState()
   const dependencies = useDependencies()
-  const usage = useProfileUsage()
+  const lastUsed = useProfileLastUsed()
   const palette = useCommandPalette()
   const [dialog, setDialog] = useState<DialogState>({ kind: 'none' })
   const [submitting, setSubmitting] = useState(false)
@@ -254,7 +254,7 @@ function AppContent() {
     'open-selected-desktop',
     () => {
       if (selected?.surfaces.gui) {
-        void usage.launchDesktop(selected.id)
+        void lastUsed.launchDesktop(selected.id)
       }
     },
     { enabled: detailEnabled },
@@ -263,7 +263,7 @@ function AppContent() {
     'copy-selected-cli',
     () => {
       if (selected?.surfaces.cli) {
-        void usage.copyCli({ profileId: selected.id, command: `claude-${selected.slug}` })
+        void lastUsed.copyCli({ profileId: selected.id, command: `claude-${selected.slug}` })
       }
     },
     { enabled: detailEnabled },
@@ -506,10 +506,10 @@ function AppContent() {
           setRightPane({ kind: 'profile' })
         }}
         onLaunch={(id) => {
-          void usage.launchDesktop(id)
+          void lastUsed.launchDesktop(id)
         }}
         onCopy={(profile) => {
-          void usage.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` })
+          void lastUsed.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` })
         }}
         onCreate={requestCreateProfile}
         onSettings={() => setRightPane({ kind: 'settings' })}

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-last-used.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-last-used.ts
@@ -13,7 +13,7 @@ function setEntry(list: Array<Profile> | undefined, updated: Profile): Array<Pro
 }
 
 /**
- * "Usage" events — launching the desktop app or copying the CLI command.
+ * Last-used events — launching the desktop app or copying the CLI command.
  * Each updates lastUsedAt server-side and appends an activity entry, so
  * after the mutation we refresh both the profile list and that profile's
  * activity timeline.
@@ -21,7 +21,7 @@ function setEntry(list: Array<Profile> | undefined, updated: Profile): Array<Pro
  * The hook returns plain async callbacks so the surface card can keep
  * its `onPrimary: () => void` interface; errors propagate to the caller.
  */
-export function useProfileUsage(): {
+export function useProfileLastUsed(): {
   launchDesktop: (profileId: string) => Promise<Profile>
   copyCli: (input: { profileId: string; command: string }) => Promise<Profile>
 } {

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
@@ -1,6 +1,9 @@
 import type { ProfileUsage } from '@/lib/types'
 
+import { QueryClient } from '@tanstack/react-query'
 import { describe, expect, it } from 'vitest'
+
+import { queryKeys } from '@/lib/query/keys'
 
 import { narrowProfileUsage } from './use-profile-usage'
 
@@ -67,5 +70,24 @@ describe('narrowProfileUsage', () => {
       fetchedAt: 'x',
     })
     expect(result.quota?.fiveHour?.utilization).toBeNull()
+  })
+})
+
+describe('profileUsage query key', () => {
+  it('is not a subkey of the profiles namespace', () => {
+    // Critical: profile-list mutations invalidate `['profiles']`, and
+    // TanStack matches by prefix. If usage were under that prefix every
+    // reorder / delete / migration would refetch every visible
+    // profile's quota in parallel and trip the rate limiter. This test
+    // pins the structural decision.
+    expect(queryKeys.profileUsage('any')[0]).not.toBe(queryKeys.profiles.all[0])
+  })
+
+  it('survives a prefix invalidation of the profiles namespace', async () => {
+    const client = new QueryClient()
+    client.setQueryData(queryKeys.profileUsage('p1'), { marker: true })
+    await client.invalidateQueries({ queryKey: queryKeys.profiles.all })
+    const state = client.getQueryState(queryKeys.profileUsage('p1'))
+    expect(state?.isInvalidated).toBe(false)
   })
 })

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
@@ -33,6 +33,15 @@ describe('narrowProfileUsage', () => {
     expect(result.quota?.fiveHour?.utilization).toBeNull()
   })
 
+  it('preserves the rate_limited quotaError', () => {
+    const result = narrowProfileUsage({
+      quota: null,
+      quotaError: 'rate_limited',
+      fetchedAt: 'x',
+    })
+    expect(result.quotaError).toBe('rate_limited')
+  })
+
   it('treats unknown quotaError values as "unknown"', () => {
     const result = narrowProfileUsage({
       quota: null,

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
@@ -41,4 +41,22 @@ describe('narrowProfileUsage', () => {
     })
     expect(result.quotaError).toBe('unknown')
   })
+
+  it('preserves utilization values above 100 (over-limit users)', () => {
+    const result = narrowProfileUsage({
+      quota: { fiveHour: { utilization: 105, resetsAt: null }, sevenDay: null, sevenDaySonnet: null },
+      quotaError: null,
+      fetchedAt: 'x',
+    })
+    expect(result.quota?.fiveHour?.utilization).toBe(105)
+  })
+
+  it('drops negative utilization to null', () => {
+    const result = narrowProfileUsage({
+      quota: { fiveHour: { utilization: -1, resetsAt: null }, sevenDay: null, sevenDaySonnet: null },
+      quotaError: null,
+      fetchedAt: 'x',
+    })
+    expect(result.quota?.fiveHour?.utilization).toBeNull()
+  })
 })

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.test.ts
@@ -1,0 +1,44 @@
+import type { ProfileUsage } from '@/lib/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { narrowProfileUsage } from './use-profile-usage'
+
+describe('narrowProfileUsage', () => {
+  it('returns the input when it already matches the expected shape', () => {
+    const input: ProfileUsage = {
+      quota: {
+        fiveHour: { utilization: 0.5, resetsAt: '2099-01-01T00:00:00Z' },
+        sevenDay: null,
+        sevenDaySonnet: null,
+      },
+      quotaError: null,
+      fetchedAt: '2099-01-01T00:00:00Z',
+    }
+    expect(narrowProfileUsage(input)).toEqual(input)
+  })
+
+  it('falls back to safe empty when input is not an object', () => {
+    const result = narrowProfileUsage('garbage')
+    expect(result.quota).toBeNull()
+    expect(result.quotaError).toBe('unknown')
+  })
+
+  it('coerces a NaN utilization to null', () => {
+    const result = narrowProfileUsage({
+      quota: { fiveHour: { utilization: Number.NaN, resetsAt: null }, sevenDay: null, sevenDaySonnet: null },
+      quotaError: null,
+      fetchedAt: 'x',
+    })
+    expect(result.quota?.fiveHour?.utilization).toBeNull()
+  })
+
+  it('treats unknown quotaError values as "unknown"', () => {
+    const result = narrowProfileUsage({
+      quota: null,
+      quotaError: 'something_new',
+      fetchedAt: 'x',
+    })
+    expect(result.quotaError).toBe('unknown')
+  })
+})

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
@@ -6,7 +6,13 @@ import { getProfileUsage } from '@/lib/commands'
 import { queryKeys } from '@/lib/query/keys'
 
 export const refetchIntervalMs = 5 * 60 * 1000
-const knownQuotaErrors: ReadonlyArray<QuotaError> = ['no_credentials', 'unauthorized', 'network', 'unknown']
+const knownQuotaErrors: ReadonlyArray<QuotaError> = [
+  'no_credentials',
+  'unauthorized',
+  'rate_limited',
+  'network',
+  'unknown',
+]
 
 /**
  * Fetches the profile's usage stats. Refetches every 5 minutes while the

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { getProfileUsage } from '@/lib/commands'
 import { queryKeys } from '@/lib/query/keys'
 
-const REFETCH_INTERVAL_MS = 5 * 60 * 1000
+export const refetchIntervalMs = 5 * 60 * 1000
 const knownQuotaErrors: ReadonlyArray<QuotaError> = ['no_credentials', 'unauthorized', 'network', 'unknown']
 
 /**
@@ -20,7 +20,7 @@ export function useProfileUsage(profileId: string) {
     queryFn: async () => narrowProfileUsage(await getProfileUsage(profileId)),
     staleTime: 0,
     refetchOnMount: 'always',
-    refetchInterval: REFETCH_INTERVAL_MS,
+    refetchInterval: refetchIntervalMs,
   })
 }
 

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
@@ -22,7 +22,7 @@ const knownQuotaErrors: ReadonlyArray<QuotaError> = [
  */
 export function useProfileUsage(profileId: string) {
   return useQuery({
-    queryKey: queryKeys.profiles.usage(profileId),
+    queryKey: queryKeys.profileUsage(profileId),
     queryFn: async () => narrowProfileUsage(await getProfileUsage(profileId)),
     staleTime: 0,
     refetchOnMount: 'always',

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
@@ -1,0 +1,88 @@
+import type { ProfileUsage, QuotaError, QuotaUsage, UsageWindow } from '@/lib/types'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { getProfileUsage } from '@/lib/commands'
+import { queryKeys } from '@/lib/query/keys'
+
+const REFETCH_INTERVAL_MS = 5 * 60 * 1000
+const knownQuotaErrors: ReadonlyArray<QuotaError> = ['no_credentials', 'unauthorized', 'network', 'unknown']
+
+/**
+ * Fetches the profile's usage stats. Refetches every 5 minutes while the
+ * query is active and on every mount, so opening the detail page always
+ * triggers a fresh fetch. The Rust command never throws for usage-fetch
+ * problems — those land in `quotaError` instead.
+ */
+export function useProfileUsage(profileId: string) {
+  return useQuery({
+    queryKey: queryKeys.profiles.usage(profileId),
+    queryFn: async () => narrowProfileUsage(await getProfileUsage(profileId)),
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchInterval: REFETCH_INTERVAL_MS,
+  })
+}
+
+function safeEmpty(): ProfileUsage {
+  return {
+    quota: null,
+    quotaError: 'unknown',
+    fetchedAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * Defensive narrowing in case the backend shape drifts (e.g. a new
+ * QuotaError variant, a missing field, NaN utilization). Anything
+ * that doesn't match falls back to safe-empty fields rather than
+ * crashing the card.
+ */
+export function narrowProfileUsage(input: unknown): ProfileUsage {
+  if (!isRecord(input)) {
+    return safeEmpty()
+  }
+  return {
+    quota: narrowQuota(input.quota),
+    quotaError: narrowQuotaError(input.quotaError),
+    fetchedAt: typeof input.fetchedAt === 'string' ? input.fetchedAt : new Date().toISOString(),
+  }
+}
+
+function narrowQuota(input: unknown): QuotaUsage | null {
+  if (!isRecord(input)) {
+    return null
+  }
+  return {
+    fiveHour: narrowWindow(input.fiveHour),
+    sevenDay: narrowWindow(input.sevenDay),
+    sevenDaySonnet: narrowWindow(input.sevenDaySonnet),
+  }
+}
+
+function narrowWindow(input: unknown): UsageWindow | null {
+  if (!isRecord(input)) {
+    return null
+  }
+  const raw = input.utilization
+  const utilization = typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : null
+  const resetsAt = typeof input.resetsAt === 'string' ? input.resetsAt : null
+  return { utilization, resetsAt }
+}
+
+function narrowQuotaError(input: unknown): QuotaError | null {
+  if (input === null || input === undefined) {
+    return null
+  }
+  if (typeof input !== 'string') {
+    return 'unknown'
+  }
+  if ((knownQuotaErrors as ReadonlyArray<string>).includes(input)) {
+    return input as QuotaError
+  }
+  return 'unknown'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
+++ b/apps/claude-profiles/src/features/profiles/api/use-profile-usage.ts
@@ -64,8 +64,11 @@ function narrowWindow(input: unknown): UsageWindow | null {
   if (!isRecord(input)) {
     return null
   }
+  // Utilization is a percentage on the 0..=100 scale. We don't clamp
+  // the upper bound — over-limit values (e.g. 105%) are legitimate and
+  // the renderer caps the visual bar separately.
   const raw = input.utilization
-  const utilization = typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : null
+  const utilization = typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 ? raw : null
   const resetsAt = typeof input.resetsAt === 'string' ? input.resetsAt : null
   return { utilization, resetsAt }
 }

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -79,6 +79,35 @@ describe('ProfileDetailUsageCard', () => {
     expect(screen.queryByRole('progressbar')).toBeNull()
   })
 
+  it.each([
+    ['unauthorized', /session expired/i],
+    ['rate_limited', /rate limited/i],
+    ['network', /couldn't reach anthropic/i],
+    ['unknown', /couldn't load usage stats/i],
+  ] as const)('shows an explicit message and no meters when quotaError is %s', (quotaError, expected) => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage({ quota: null, quotaError }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it('shows the unknown-error message when quota is null with no quotaError (defensive)', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage({ quota: null, quotaError: null }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    expect(screen.getByText(/couldn't load usage stats/i)).toBeInTheDocument()
+  })
+
   it('calls refetch when the refresh button is clicked', () => {
     const refetch = vi.fn()
     ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -80,7 +80,7 @@ describe('ProfileDetailUsageCard', () => {
   })
 
   it.each([
-    ['unauthorized', /session expired/i],
+    ['unauthorized', /token refresh needed/i],
     ['rate_limited', /rate limited/i],
     ['network', /couldn't reach anthropic/i],
     ['unknown', /couldn't load usage stats/i],

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from 'react'
+import type { ProfileUsage } from '@/lib/types'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useProfileUsage } from '../api/use-profile-usage'
+import { ProfileDetailUsageCard } from './profile-detail-usage-card'
+
+// vi.mock is hoisted above all imports — the import above resolves to the
+// mocked module at test time.
+vi.mock('../api/use-profile-usage', () => ({
+  useProfileUsage: vi.fn(),
+}))
+
+function makeUsage(overrides: Partial<ProfileUsage> = {}): ProfileUsage {
+  return {
+    quota: {
+      fiveHour: { utilization: 0.63, resetsAt: null },
+      sevenDay: { utilization: 0.21, resetsAt: null },
+      sevenDaySonnet: { utilization: 0.08, resetsAt: null },
+    },
+    quotaError: null,
+    fetchedAt: '2099-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderWithQuery(children: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>)
+}
+
+describe('ProfileDetailUsageCard', () => {
+  it('renders three progressbars with the right aria-valuenow', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage(),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    const bars = screen.getAllByRole('progressbar')
+    expect(bars).toHaveLength(3)
+    expect(bars[0]).toHaveAttribute('aria-valuenow', '63')
+    expect(bars[1]).toHaveAttribute('aria-valuenow', '21')
+    expect(bars[2]).toHaveAttribute('aria-valuenow', '8')
+  })
+
+  it('omits aria-valuenow when utilization is null', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage({
+        quota: {
+          fiveHour: { utilization: null, resetsAt: null },
+          sevenDay: { utilization: 0.21, resetsAt: null },
+          sevenDaySonnet: { utilization: 0.08, resetsAt: null },
+        },
+      }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    const bars = screen.getAllByRole('progressbar')
+    expect(bars[0]).not.toHaveAttribute('aria-valuenow')
+  })
+
+  it('hides the meters when quotaError is no_credentials', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage({ quota: null, quotaError: 'no_credentials' }),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    expect(screen.queryByRole('progressbar')).toBeNull()
+  })
+
+  it('calls refetch when the refresh button is clicked', () => {
+    const refetch = vi.fn()
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage(),
+      isLoading: false,
+      isFetching: false,
+      refetch,
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when CLI is not enabled for the profile', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage(),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    const { container } = renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -12,6 +12,7 @@ import { ProfileDetailUsageCard } from './profile-detail-usage-card'
 // mocked module at test time.
 vi.mock('../api/use-profile-usage', () => ({
   useProfileUsage: vi.fn(),
+  refetchIntervalMs: 5 * 60 * 1000,
 }))
 
 function makeUsage(overrides: Partial<ProfileUsage> = {}): ProfileUsage {
@@ -99,5 +100,32 @@ describe('ProfileDetailUsageCard', () => {
     })
     const { container } = renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={false} />)
     expect(container.firstChild).toBeNull()
+  })
+
+  it('shows "refresh in Xm" countdown derived from dataUpdatedAt', () => {
+    // Fetched just now; with a 5-minute refetch interval the countdown
+    // should land at "4m" (5 minutes minus the few ms between Date.now()
+    // calls). Loose regex tolerates the off-by-one between 4m and 5m.
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage(),
+      isLoading: false,
+      isFetching: false,
+      dataUpdatedAt: Date.now(),
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    expect(screen.getByText(/refresh in [45]m/)).toBeInTheDocument()
+  })
+
+  it('shows "refreshing…" while a fetch is in flight', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: makeUsage(),
+      isLoading: false,
+      isFetching: true,
+      dataUpdatedAt: Date.now(),
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    expect(screen.getByText(/refreshing/)).toBeInTheDocument()
   })
 })

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -158,4 +158,77 @@ describe('ProfileDetailUsageCard', () => {
     renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
     expect(screen.getByText(/refreshing/)).toBeInTheDocument()
   })
+
+  it('clears the error fallback when profileId changes', () => {
+    const usageMock = useProfileUsage as ReturnType<typeof vi.fn>
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    // While profile p1 is mounted, throw to drive the boundary into
+    // its hasError state. Switching to p2 changes the boundary's `key`
+    // so it remounts with a fresh state.
+    usageMock.mockImplementation((profileId: string) => {
+      if (profileId === 'p1') {
+        throw new Error('boom')
+      }
+      return {
+        data: makeUsage(),
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      }
+    })
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <ProfileDetailUsageCard profileId="p1" cliEnabled={true} />
+      </QueryClientProvider>,
+    )
+    expect(screen.getByText(/couldn't display usage stats/i)).toBeInTheDocument()
+
+    rerender(
+      <QueryClientProvider client={client}>
+        <ProfileDetailUsageCard profileId="p2" cliEnabled={true} />
+      </QueryClientProvider>,
+    )
+    expect(screen.queryByText(/couldn't display usage stats/i)).toBeNull()
+    expect(screen.getAllByRole('progressbar')).toHaveLength(3)
+
+    consoleError.mockRestore()
+    consoleWarn.mockRestore()
+  })
+
+  it('Retry recovers the card by remounting the inner query', () => {
+    const usageMock = useProfileUsage as ReturnType<typeof vi.fn>
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    // Throw until the Retry click flips the flag — Retry bumps the
+    // parent's `attempt` counter, which changes the boundary's key,
+    // which remounts the boundary AND the inner query.
+    let throwing = true
+    usageMock.mockImplementation(() => {
+      if (throwing) {
+        throw new Error('boom')
+      }
+      return {
+        data: makeUsage(),
+        isLoading: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      }
+    })
+
+    renderWithQuery(<ProfileDetailUsageCard profileId="p1" cliEnabled={true} />)
+    expect(screen.getByText(/couldn't display usage stats/i)).toBeInTheDocument()
+
+    throwing = false
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(screen.queryByText(/couldn't display usage stats/i)).toBeNull()
+    expect(screen.getAllByRole('progressbar')).toHaveLength(3)
+
+    consoleError.mockRestore()
+    consoleWarn.mockRestore()
+  })
 })

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -18,9 +18,10 @@ vi.mock('../api/use-profile-usage', () => ({
 function makeUsage(overrides: Partial<ProfileUsage> = {}): ProfileUsage {
   return {
     quota: {
-      fiveHour: { utilization: 0.63, resetsAt: null },
-      sevenDay: { utilization: 0.21, resetsAt: null },
-      sevenDaySonnet: { utilization: 0.08, resetsAt: null },
+      // Utilization is a 0..=100 percentage — matches Anthropic's response.
+      fiveHour: { utilization: 63, resetsAt: null },
+      sevenDay: { utilization: 21, resetsAt: null },
+      sevenDaySonnet: { utilization: 8, resetsAt: null },
     },
     quotaError: null,
     fetchedAt: '2099-01-01T00:00:00Z',
@@ -54,8 +55,8 @@ describe('ProfileDetailUsageCard', () => {
       data: makeUsage({
         quota: {
           fiveHour: { utilization: null, resetsAt: null },
-          sevenDay: { utilization: 0.21, resetsAt: null },
-          sevenDaySonnet: { utilization: 0.08, resetsAt: null },
+          sevenDay: { utilization: 21, resetsAt: null },
+          sevenDaySonnet: { utilization: 8, resetsAt: null },
         },
       }),
       isLoading: false,

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react'
 import type { ProfileUsage, UsageWindow } from '@/lib/types'
 
-import { Component } from 'react'
+import { Component, useEffect, useState } from 'react'
 
 import { RefreshCw } from 'lucide-react'
 
-import { useProfileUsage } from '../api/use-profile-usage'
+import { refetchIntervalMs, useProfileUsage } from '../api/use-profile-usage'
 
 type Props = {
   profileId: string
@@ -24,26 +24,64 @@ export function ProfileDetailUsageCard({ profileId, cliEnabled }: Props) {
 }
 
 function UsageCardInner({ profileId }: { profileId: string }) {
-  const { data, isLoading, isFetching, isError, refetch } = useProfileUsage(profileId)
+  const { data, isLoading, isFetching, isError, dataUpdatedAt, refetch } = useProfileUsage(profileId)
 
   return (
     <section className="mb-6 rounded-md border border-border p-4">
       <header className="mb-3 flex items-center justify-between">
         <div className="font-mono text-eyebrow font-medium uppercase tracking-[0.1em] text-muted-strong">Usage</div>
-        <button
-          type="button"
-          aria-label="Refresh usage"
-          disabled={isFetching}
-          onClick={() => refetch()}
-          className="text-muted-strong hover:text-fg disabled:opacity-50"
-        >
-          <RefreshCw size={14} className={isFetching ? 'animate-spin' : undefined} />
-        </button>
+        <div className="flex items-center gap-2">
+          <RefreshCountdown isFetching={isFetching} dataUpdatedAt={dataUpdatedAt} />
+          <button
+            type="button"
+            aria-label="Refresh usage"
+            disabled={isFetching}
+            onClick={() => refetch()}
+            className="cursor-pointer text-muted-strong hover:text-fg disabled:cursor-default disabled:opacity-50"
+          >
+            <RefreshCw size={14} className={isFetching ? 'animate-spin' : undefined} />
+          </button>
+        </div>
       </header>
 
       {isLoading ? <MetersSkeleton /> : <Body usage={data ?? null} isError={isError} />}
     </section>
   )
+}
+
+function RefreshCountdown({ isFetching, dataUpdatedAt }: { isFetching: boolean; dataUpdatedAt: number | undefined }) {
+  // Force re-render every 5s so the countdown ticks down without us
+  // wiring an explicit timer per second. 5s is plenty since the label
+  // resolution is minutes for most of the window.
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setTick((value) => value + 1), 5_000)
+    return () => clearInterval(id)
+  }, [])
+
+  if (isFetching) {
+    return <span className="font-mono text-mono text-muted-strong">refreshing…</span>
+  }
+  if (!dataUpdatedAt) {
+    return null
+  }
+  const remainingMs = dataUpdatedAt + refetchIntervalMs - Date.now()
+  const label = formatRefreshIn(remainingMs)
+  if (!label) {
+    return null
+  }
+  return <span className="font-mono text-mono text-muted-strong">refresh in {label}</span>
+}
+
+function formatRefreshIn(deltaMs: number): string | null {
+  if (deltaMs <= 0) {
+    return 'soon'
+  }
+  const totalSeconds = Math.floor(deltaMs / 1000)
+  if (totalSeconds >= 60) {
+    return `${Math.floor(totalSeconds / 60)}m`
+  }
+  return `${totalSeconds}s`
 }
 
 function Body({ usage, isError }: { usage: ProfileUsage | null; isError: boolean }) {
@@ -73,14 +111,29 @@ function Body({ usage, isError }: { usage: ProfileUsage | null; isError: boolean
 function Meters({ quota }: { quota: ProfileUsage['quota'] }) {
   return (
     <div className="flex flex-col gap-2">
-      <Meter label="5-hour window" meterWindow={quota?.fiveHour ?? null} />
-      <Meter label="Weekly" meterWindow={quota?.sevenDay ?? null} />
-      <Meter label="Weekly Sonnet" meterWindow={quota?.sevenDaySonnet ?? null} />
+      <Meter label="5-hour window" shortLabel="5h" meterWindow={quota?.fiveHour ?? null} />
+      <Meter label="Weekly" shortLabel="W" meterWindow={quota?.sevenDay ?? null} />
+      <Meter label="Weekly Sonnet" shortLabel="WS" meterWindow={quota?.sevenDaySonnet ?? null} />
     </div>
   )
 }
 
-function Meter({ label, meterWindow }: { label: string; meterWindow: UsageWindow | null }) {
+// Layout: [label] [bar (1fr)] [trailing text fixed width]. The fixed
+// trailing column keeps every bar exactly the same width across rows
+// and reserves space for the longest "100% · resets in 23h 59m"
+// string (~22 mono chars ≈ 180px). The label column shrinks at narrow
+// viewports so the bar still has room to breathe.
+const meterGridClass = 'grid grid-cols-[32px_1fr_180px] items-center gap-2 lg:grid-cols-[140px_1fr_180px] lg:gap-3'
+
+function Meter({
+  label,
+  shortLabel,
+  meterWindow,
+}: {
+  label: string
+  shortLabel: string
+  meterWindow: UsageWindow | null
+}) {
   const utilization = meterWindow?.utilization ?? null
   const percent = utilization === null ? null : Math.round(utilization * 100)
   const tone = percent === null ? 'muted' : percent < 50 ? 'ok' : percent < 80 ? 'warn' : 'crit'
@@ -89,8 +142,11 @@ function Meter({ label, meterWindow }: { label: string; meterWindow: UsageWindow
   const resetsLabel = formatReset(meterWindow?.resetsAt ?? null)
 
   return (
-    <div className="grid grid-cols-[140px_1fr_auto] items-center gap-3">
-      <span className="font-mono text-mono text-muted-strong">{label}</span>
+    <div className={meterGridClass}>
+      <span className="font-mono text-mono text-muted-strong">
+        <span className="lg:hidden">{shortLabel}</span>
+        <span className="hidden lg:inline">{label}</span>
+      </span>
       <div
         role="progressbar"
         aria-valuenow={percent ?? undefined}
@@ -101,7 +157,7 @@ function Meter({ label, meterWindow }: { label: string; meterWindow: UsageWindow
       >
         <div className={`h-full ${barClass}`} style={{ width: percent === null ? 0 : `${percent}%` }} />
       </div>
-      <span className="font-mono text-mono tabular-nums text-muted-strong">
+      <span className="text-right font-mono text-mono tabular-nums text-muted-strong">
         {percent === null ? '—' : `${percent}%`}
         {resetsLabel ? ` · ${resetsLabel}` : ''}
       </span>
@@ -137,10 +193,10 @@ function MetersSkeleton() {
   return (
     <div className="flex flex-col gap-2">
       {[0, 1, 2].map((row) => (
-        <div key={row} className="grid grid-cols-[140px_1fr_auto] items-center gap-3">
-          <span className="h-3 w-24 rounded bg-cream-2" />
+        <div key={row} className={meterGridClass}>
+          <span className="h-3 w-full rounded bg-cream-2" />
           <span className="h-2 w-full rounded bg-cream-2" />
-          <span className="h-3 w-10 rounded bg-cream-2" />
+          <span className="h-3 w-full rounded bg-cream-2" />
         </div>
       ))}
     </div>

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -107,7 +107,11 @@ function quotaErrorMessage(quotaError: ProfileUsage['quotaError'], quota: Profil
     return 'Sign in to Claude Code once with this profile to see usage.'
   }
   if (quotaError === 'unauthorized') {
-    return 'Session expired — sign in again with this profile to refresh usage.'
+    // Not a real "session expired" — Claude Code's short-lived access
+    // token rolls over every ~hour and is silently refreshed the next
+    // time you invoke `claude`. Same step also handles the rarer case
+    // where the token was actually revoked (claude will prompt re-login).
+    return 'Token refresh needed — run `claude` in a terminal once, then retry.'
   }
   if (quotaError === 'rate_limited') {
     return 'Rate limited by Anthropic. Try again in a few minutes.'

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -91,21 +91,37 @@ function Body({ usage, isError }: { usage: ProfileUsage | null; isError: boolean
   if (!usage) {
     return <MetersSkeleton />
   }
-  if (usage.quotaError === 'no_credentials') {
-    return (
-      <p className="font-mono text-mono text-muted-strong">
-        Sign in to Claude Code once with this profile to see usage.
-      </p>
-    )
-  }
-  if (usage.quotaError === 'unauthorized') {
-    return (
-      <p className="font-mono text-mono text-muted-strong">
-        Session expired — sign in again with this profile to refresh usage.
-      </p>
-    )
+  const quotaMessage = quotaErrorMessage(usage.quotaError, usage.quota)
+  if (quotaMessage) {
+    return <p className="font-mono text-mono text-muted-strong">{quotaMessage}</p>
   }
   return <Meters quota={usage.quota} />
+}
+
+// Returns the message to show in place of the meters, or null if the
+// meters should render. We treat "quota is null AND no recognised error"
+// the same as `unknown` so we never silently render empty bars when the
+// backend gave us nothing usable.
+function quotaErrorMessage(quotaError: ProfileUsage['quotaError'], quota: ProfileUsage['quota']): string | null {
+  if (quotaError === 'no_credentials') {
+    return 'Sign in to Claude Code once with this profile to see usage.'
+  }
+  if (quotaError === 'unauthorized') {
+    return 'Session expired — sign in again with this profile to refresh usage.'
+  }
+  if (quotaError === 'rate_limited') {
+    return 'Rate limited by Anthropic. Try again in a few minutes.'
+  }
+  if (quotaError === 'network') {
+    return "Couldn't reach Anthropic — check your connection and retry."
+  }
+  if (quotaError === 'unknown') {
+    return "Couldn't load usage stats. Try again."
+  }
+  if (!quota) {
+    return "Couldn't load usage stats. Try again."
+  }
+  return null
 }
 
 function Meters({ quota }: { quota: ProfileUsage['quota'] }) {

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -13,11 +13,17 @@ type Props = {
 }
 
 export function ProfileDetailUsageCard({ profileId, cliEnabled }: Props) {
+  // Bumped by the in-boundary Retry button to force the inner query
+  // to re-run after a render-time crash. We use it (alongside profileId)
+  // as the key on the boundary itself, so switching profiles or hitting
+  // Retry remounts the boundary — its hasError state resets along with
+  // the inner useQuery's cache subscription.
+  const [attempt, setAttempt] = useState(0)
   if (!cliEnabled) {
     return null
   }
   return (
-    <UsageCardErrorBoundary>
+    <UsageCardErrorBoundary key={`${profileId}:${attempt}`} onRetry={() => setAttempt((value) => value + 1)}>
       <UsageCardInner profileId={profileId} />
     </UsageCardErrorBoundary>
   )
@@ -290,9 +296,10 @@ function MetersSkeleton() {
   )
 }
 
+type BoundaryProps = { children: ReactNode; onRetry: () => void }
 type BoundaryState = { hasError: boolean }
 
-class UsageCardErrorBoundary extends Component<{ children: ReactNode }, BoundaryState> {
+class UsageCardErrorBoundary extends Component<BoundaryProps, BoundaryState> {
   state: BoundaryState = { hasError: false }
   static getDerivedStateFromError(): BoundaryState {
     return { hasError: true }
@@ -302,11 +309,16 @@ class UsageCardErrorBoundary extends Component<{ children: ReactNode }, Boundary
   }
   render() {
     if (this.state.hasError) {
+      // Retry delegates to the parent so it can bump the attempt
+      // counter — that key change is what actually remounts the
+      // boundary (clearing hasError) and the inner card (re-running
+      // useQuery). Toggling local state here alone would clear the
+      // fallback but leave the same broken inner element mounted.
       return (
         <section className="mb-6 rounded-md border border-border p-4">
           <p className="font-mono text-mono text-muted-strong">
             Couldn't display usage stats.{' '}
-            <button type="button" className="underline" onClick={() => this.setState({ hasError: false })}>
+            <button type="button" className="underline" onClick={this.props.onRetry}>
               Retry
             </button>
           </p>

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -1,0 +1,175 @@
+import type { ReactNode } from 'react'
+import type { ProfileUsage, UsageWindow } from '@/lib/types'
+
+import { Component } from 'react'
+
+import { RefreshCw } from 'lucide-react'
+
+import { useProfileUsage } from '../api/use-profile-usage'
+
+type Props = {
+  profileId: string
+  cliEnabled: boolean
+}
+
+export function ProfileDetailUsageCard({ profileId, cliEnabled }: Props) {
+  if (!cliEnabled) {
+    return null
+  }
+  return (
+    <UsageCardErrorBoundary>
+      <UsageCardInner profileId={profileId} />
+    </UsageCardErrorBoundary>
+  )
+}
+
+function UsageCardInner({ profileId }: { profileId: string }) {
+  const { data, isLoading, isFetching, isError, refetch } = useProfileUsage(profileId)
+
+  return (
+    <section className="mb-6 rounded-md border border-border p-4">
+      <header className="mb-3 flex items-center justify-between">
+        <div className="font-mono text-eyebrow font-medium uppercase tracking-[0.1em] text-muted-strong">Usage</div>
+        <button
+          type="button"
+          aria-label="Refresh usage"
+          disabled={isFetching}
+          onClick={() => refetch()}
+          className="text-muted-strong hover:text-fg disabled:opacity-50"
+        >
+          <RefreshCw size={14} className={isFetching ? 'animate-spin' : undefined} />
+        </button>
+      </header>
+
+      {isLoading ? <MetersSkeleton /> : <Body usage={data ?? null} isError={isError} />}
+    </section>
+  )
+}
+
+function Body({ usage, isError }: { usage: ProfileUsage | null; isError: boolean }) {
+  if (isError) {
+    return <p className="font-mono text-mono text-muted-strong">Couldn't load usage stats.</p>
+  }
+  if (!usage) {
+    return <MetersSkeleton />
+  }
+  if (usage.quotaError === 'no_credentials') {
+    return (
+      <p className="font-mono text-mono text-muted-strong">
+        Sign in to Claude Code once with this profile to see usage.
+      </p>
+    )
+  }
+  if (usage.quotaError === 'unauthorized') {
+    return (
+      <p className="font-mono text-mono text-muted-strong">
+        Session expired — sign in again with this profile to refresh usage.
+      </p>
+    )
+  }
+  return <Meters quota={usage.quota} />
+}
+
+function Meters({ quota }: { quota: ProfileUsage['quota'] }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Meter label="5-hour window" meterWindow={quota?.fiveHour ?? null} />
+      <Meter label="Weekly" meterWindow={quota?.sevenDay ?? null} />
+      <Meter label="Weekly Sonnet" meterWindow={quota?.sevenDaySonnet ?? null} />
+    </div>
+  )
+}
+
+function Meter({ label, meterWindow }: { label: string; meterWindow: UsageWindow | null }) {
+  const utilization = meterWindow?.utilization ?? null
+  const percent = utilization === null ? null : Math.round(utilization * 100)
+  const tone = percent === null ? 'muted' : percent < 50 ? 'ok' : percent < 80 ? 'warn' : 'crit'
+  const barClass =
+    tone === 'ok' ? 'bg-green' : tone === 'warn' ? 'bg-amber' : tone === 'crit' ? 'bg-red' : 'bg-muted-strong'
+  const resetsLabel = formatReset(meterWindow?.resetsAt ?? null)
+
+  return (
+    <div className="grid grid-cols-[140px_1fr_auto] items-center gap-3">
+      <span className="font-mono text-mono text-muted-strong">{label}</span>
+      <div
+        role="progressbar"
+        aria-valuenow={percent ?? undefined}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label}
+        className="h-2 overflow-hidden rounded bg-cream-2"
+      >
+        <div className={`h-full ${barClass}`} style={{ width: percent === null ? 0 : `${percent}%` }} />
+      </div>
+      <span className="font-mono text-mono tabular-nums text-muted-strong">
+        {percent === null ? '—' : `${percent}%`}
+        {resetsLabel ? ` · ${resetsLabel}` : ''}
+      </span>
+    </div>
+  )
+}
+
+function formatReset(resetsAt: string | null): string | null {
+  if (!resetsAt) {
+    return null
+  }
+  const date = new Date(resetsAt)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  const deltaMs = date.getTime() - Date.now()
+  if (deltaMs <= 0) {
+    return 'resets soon'
+  }
+  const hours = Math.floor(deltaMs / (60 * 60 * 1000))
+  const minutes = Math.floor((deltaMs % (60 * 60 * 1000)) / (60 * 1000))
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24)
+    return `resets in ${days}d`
+  }
+  if (hours >= 1) {
+    return `resets in ${hours}h ${minutes}m`
+  }
+  return `resets in ${minutes}m`
+}
+
+function MetersSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {[0, 1, 2].map((row) => (
+        <div key={row} className="grid grid-cols-[140px_1fr_auto] items-center gap-3">
+          <span className="h-3 w-24 rounded bg-cream-2" />
+          <span className="h-2 w-full rounded bg-cream-2" />
+          <span className="h-3 w-10 rounded bg-cream-2" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+type BoundaryState = { hasError: boolean }
+
+class UsageCardErrorBoundary extends Component<{ children: ReactNode }, BoundaryState> {
+  state: BoundaryState = { hasError: false }
+  static getDerivedStateFromError(): BoundaryState {
+    return { hasError: true }
+  }
+  componentDidCatch(error: Error) {
+    console.warn('Usage card render failed', error)
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <section className="mb-6 rounded-md border border-border p-4">
+          <p className="font-mono text-mono text-muted-strong">
+            Couldn't display usage stats.{' '}
+            <button type="button" className="underline" onClick={() => this.setState({ hasError: false })}>
+              Retry
+            </button>
+          </p>
+        </section>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -134,8 +134,12 @@ function Meter({
   shortLabel: string
   meterWindow: UsageWindow | null
 }) {
+  // utilization comes from the API on a 0..=100 percentage scale and
+  // may exceed 100 when the user is over-limit. We show the literal
+  // value in the label but cap the visual bar fill at 100%.
   const utilization = meterWindow?.utilization ?? null
-  const percent = utilization === null ? null : Math.round(utilization * 100)
+  const percent = utilization === null ? null : Math.round(utilization)
+  const fillPercent = percent === null ? 0 : Math.min(100, Math.max(0, percent))
   const tone = percent === null ? 'muted' : percent < 50 ? 'ok' : percent < 80 ? 'warn' : 'crit'
   const barClass =
     tone === 'ok' ? 'bg-green' : tone === 'warn' ? 'bg-amber' : tone === 'crit' ? 'bg-red' : 'bg-muted-strong'
@@ -155,7 +159,7 @@ function Meter({
         aria-label={label}
         className="h-2 overflow-hidden rounded bg-cream-2"
       >
-        <div className={`h-full ${barClass}`} style={{ width: percent === null ? 0 : `${percent}%` }} />
+        <div className={`h-full ${barClass}`} style={{ width: `${fillPercent}%` }} />
       </div>
       <span className="text-right font-mono text-mono tabular-nums text-muted-strong">
         {percent === null ? '—' : `${percent}%`}

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -132,8 +132,8 @@ function Meters({ quota }: { quota: ProfileUsage['quota'] }) {
   return (
     <div className="flex flex-col gap-2">
       <Meter label="5-hour window" shortLabel="5h" meterWindow={quota?.fiveHour ?? null} />
-      <Meter label="Weekly" shortLabel="W" meterWindow={quota?.sevenDay ?? null} />
-      <Meter label="Weekly Sonnet" shortLabel="WS" meterWindow={quota?.sevenDaySonnet ?? null} />
+      <Meter showDailySegments label="Weekly" shortLabel="W" meterWindow={quota?.sevenDay ?? null} />
+      <Meter showDailySegments label="Weekly Sonnet" shortLabel="WS" meterWindow={quota?.sevenDaySonnet ?? null} />
     </div>
   )
 }
@@ -149,10 +149,12 @@ function Meter({
   label,
   shortLabel,
   meterWindow,
+  showDailySegments = false,
 }: {
   label: string
   shortLabel: string
   meterWindow: UsageWindow | null
+  showDailySegments?: boolean
 }) {
   // utilization comes from the API on a 0..=100 percentage scale and
   // may exceed 100 when the user is over-limit. We show the literal
@@ -164,6 +166,7 @@ function Meter({
   const barClass =
     tone === 'ok' ? 'bg-green' : tone === 'warn' ? 'bg-amber' : tone === 'crit' ? 'bg-red' : 'bg-muted-strong'
   const resetsLabel = formatReset(meterWindow?.resetsAt ?? null)
+  const pacePercent = showDailySegments ? computeWeeklyPacePercent(meterWindow?.resetsAt ?? null) : null
 
   return (
     <div className={meterGridClass}>
@@ -171,15 +174,19 @@ function Meter({
         <span className="lg:hidden">{shortLabel}</span>
         <span className="hidden lg:inline">{label}</span>
       </span>
-      <div
-        role="progressbar"
-        aria-valuenow={percent ?? undefined}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-label={label}
-        className="h-2 overflow-hidden rounded bg-cream-2"
-      >
-        <div className={`h-full ${barClass}`} style={{ width: `${fillPercent}%` }} />
+      <div className="relative">
+        <div
+          role="progressbar"
+          aria-valuenow={percent ?? undefined}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={label}
+          className="relative h-2 overflow-hidden rounded bg-cream-2"
+        >
+          <div className={`h-full ${barClass}`} style={{ width: `${fillPercent}%` }} />
+          {showDailySegments ? <DaySeparators /> : null}
+        </div>
+        {pacePercent === null ? null : <PaceMarker percent={pacePercent} />}
       </div>
       <span className="text-right font-mono text-mono tabular-nums text-muted-strong">
         {percent === null ? '—' : `${percent}%`}
@@ -187,6 +194,62 @@ function Meter({
       </span>
     </div>
   )
+}
+
+function DaySeparators() {
+  return (
+    <>
+      {[1, 2, 3, 4, 5, 6].map((day) => (
+        <div
+          key={day}
+          aria-hidden
+          className="pointer-events-none absolute top-0 h-full w-px bg-ink/10"
+          style={{ left: `${(day / 7) * 100}%` }}
+        />
+      ))}
+    </>
+  )
+}
+
+function PaceMarker({ percent }: { percent: number }) {
+  const clamped = Math.min(100, Math.max(0, percent))
+  return (
+    <div
+      className="group absolute -top-0.5 flex h-3 w-3 items-center justify-center"
+      style={{ left: `calc(${clamped}% - 6px)` }}
+    >
+      <div aria-hidden className="pointer-events-none h-full w-0.5 rounded-sm bg-ink" />
+      <div
+        role="tooltip"
+        className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-ink px-2 py-1 font-mono text-mono text-cream opacity-0 shadow-md transition-opacity group-hover:opacity-100"
+      >
+        Even daily pace · {Math.round(clamped)}%
+      </div>
+    </div>
+  )
+}
+
+// Weekly limits reset at a fixed time on a 7-day cycle, so the "expected"
+// burn position is just how far we've travelled from the previous reset
+// (resetsAt - 7d) toward the next one. Returns null when the input is
+// missing or out of range.
+function computeWeeklyPacePercent(resetsAt: string | null): number | null {
+  if (!resetsAt) {
+    return null
+  }
+  const resetTime = new Date(resetsAt).getTime()
+  if (Number.isNaN(resetTime)) {
+    return null
+  }
+  const windowMs = 7 * 24 * 60 * 60 * 1000
+  const timeRemaining = resetTime - Date.now()
+  if (timeRemaining <= 0) {
+    return 100
+  }
+  if (timeRemaining >= windowMs) {
+    return 0
+  }
+  return ((windowMs - timeRemaining) / windowMs) * 100
 }
 
 function formatReset(resetsAt: string | null): string | null {

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail.tsx
@@ -15,6 +15,7 @@ import { ProfileDetailHeader } from './profile-detail-header'
 import { ProfileDetailHintStrip } from './profile-detail-hint-strip'
 import { ProfileDetailRecentActivity } from './profile-detail-recent-activity'
 import { ProfileDetailSurfaceCard } from './profile-detail-surface-card'
+import { ProfileDetailUsageCard } from './profile-detail-usage-card'
 
 type Props = {
   profile: Profile
@@ -59,6 +60,8 @@ export function ProfileDetail({ profile, onEdit, onDelete }: Props) {
       <div className="flex-1 overflow-y-auto px-10 pt-10">
         <div className="mx-auto w-full max-w-[640px]">
           <ProfileDetailHeader profile={profile} onEdit={onEdit} />
+
+          <ProfileDetailUsageCard profileId={profile.id} cliEnabled={profile.surfaces.cli} />
 
           <div className="mb-6 grid grid-cols-1 gap-3.5 lg:grid-cols-2">
             {/* Re-keying on profile.id ensures the loaded paths state doesn't

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail.tsx
@@ -7,8 +7,8 @@ import { useShortcut } from '@/design'
 import { useDependencies } from '@/features/dependencies/api/use-dependencies'
 import { openInFinder } from '@/lib/commands'
 
+import { useProfileLastUsed } from '../api/use-profile-last-used'
 import { useProfilePaths } from '../api/use-profile-paths'
-import { useProfileUsage } from '../api/use-profile-usage'
 import { DeepLinkInfo } from './deep-link-info'
 import { ProfileDetailDangerLink } from './profile-detail-danger-link'
 import { ProfileDetailHeader } from './profile-detail-header'
@@ -91,7 +91,7 @@ type SurfaceCardsLoadedProps = {
 function SurfaceCardsLoaded({ profile, onError }: SurfaceCardsLoadedProps) {
   const paths = useProfilePaths(profile.id)
   const dependencies = useDependencies()
-  const usage = useProfileUsage()
+  const lastUsed = useProfileLastUsed()
 
   async function safeRun(action: () => Promise<unknown>) {
     try {
@@ -137,7 +137,7 @@ function SurfaceCardsLoaded({ profile, onError }: SurfaceCardsLoadedProps) {
           { label: 'Reveal app', kbd: '⌥1', onClick: () => safeRun(() => openInFinder(paths.guiDataDir)) },
           { label: 'Launcher', kbd: '⌥2', onClick: () => safeRun(() => openInFinder(paths.guiLauncherPath)) },
         ]}
-        onPrimary={() => safeRun(() => usage.launchDesktop(profile.id))}
+        onPrimary={() => safeRun(() => lastUsed.launchDesktop(profile.id))}
       />
       <ProfileDetailSurfaceCard
         variant="cli"
@@ -154,14 +154,14 @@ function SurfaceCardsLoaded({ profile, onError }: SurfaceCardsLoadedProps) {
           { label: 'Config', kbd: '⌥3', onClick: () => safeRun(() => openInFinder(paths.cliConfigDir)) },
           { label: 'Wrapper', kbd: '⌥4', onClick: () => safeRun(() => openInFinder(paths.cliWrapperPath)) },
         ]}
-        onPrimary={() => safeRun(() => usage.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` }))}
+        onPrimary={() => safeRun(() => lastUsed.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` }))}
       />
     </>
   )
 }
 
 function SurfaceCardsFallback({ profile }: { profile: Profile }) {
-  const usage = useProfileUsage()
+  const lastUsed = useProfileLastUsed()
   return (
     <>
       <ProfileDetailSurfaceCard
@@ -174,7 +174,7 @@ function SurfaceCardsFallback({ profile }: { profile: Profile }) {
           { label: 'Reveal app', kbd: '⌥1' },
           { label: 'Launcher', kbd: '⌥2' },
         ]}
-        onPrimary={() => usage.launchDesktop(profile.id)}
+        onPrimary={() => lastUsed.launchDesktop(profile.id)}
       />
       <ProfileDetailSurfaceCard
         variant="cli"
@@ -189,7 +189,7 @@ function SurfaceCardsFallback({ profile }: { profile: Profile }) {
           { label: 'Config', kbd: '⌥3' },
           { label: 'Wrapper', kbd: '⌥4' },
         ]}
-        onPrimary={() => usage.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` })}
+        onPrimary={() => lastUsed.copyCli({ profileId: profile.id, command: `claude-${profile.slug}` })}
       />
     </>
   )

--- a/apps/claude-profiles/src/lib/commands.ts
+++ b/apps/claude-profiles/src/lib/commands.ts
@@ -13,6 +13,7 @@ import type {
   Profile,
   ProfilePatch,
   ProfilePaths,
+  ProfileUsage,
   Shell,
   Surface,
   Surfaces,
@@ -119,4 +120,8 @@ export function getAppMetadata(): Promise<AppMetadata> {
 
 export function openExternalUrl(url: string): Promise<void> {
   return invoke('open_external_url', { url })
+}
+
+export function getProfileUsage(profileId: string): Promise<ProfileUsage> {
+  return invoke<ProfileUsage>('get_profile_usage', { profileId })
 }

--- a/apps/claude-profiles/src/lib/query/keys.ts
+++ b/apps/claude-profiles/src/lib/query/keys.ts
@@ -11,8 +11,12 @@ export const queryKeys = {
     detail: (id: string) => ['profiles', id] as const,
     paths: (id: string) => ['profiles', id, 'paths'] as const,
     activity: (id: string) => ['profiles', id, 'activity'] as const,
-    usage: (id: string) => ['profiles', id, 'usage'] as const,
   },
+  // Per-profile Anthropic usage stats. Deliberately OUTSIDE the
+  // `profiles` subtree so a prefix invalidation of `['profiles']`
+  // (which fires on reorder/delete/migration) doesn't refetch every
+  // visible profile's quota in parallel and trip the rate limiter.
+  profileUsage: (id: string) => ['profile-usage', id] as const,
   dependencies: ['dependencies'] as const,
   migration: {
     existing: ['migration', 'existing'] as const,

--- a/apps/claude-profiles/src/lib/query/keys.ts
+++ b/apps/claude-profiles/src/lib/query/keys.ts
@@ -11,6 +11,7 @@ export const queryKeys = {
     detail: (id: string) => ['profiles', id] as const,
     paths: (id: string) => ['profiles', id, 'paths'] as const,
     activity: (id: string) => ['profiles', id, 'activity'] as const,
+    usage: (id: string) => ['profiles', id, 'usage'] as const,
   },
   dependencies: ['dependencies'] as const,
   migration: {

--- a/apps/claude-profiles/src/lib/query/provider.tsx
+++ b/apps/claude-profiles/src/lib/query/provider.tsx
@@ -16,7 +16,7 @@ export function QueryProvider({ children }: QueryProviderProps) {
   return (
     <QueryClientProvider client={client}>
       {children}
-      {import.meta.env.DEV ? <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" /> : null}
+      {import.meta.env.DEV ? <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" /> : null}
     </QueryClientProvider>
   )
 }

--- a/apps/claude-profiles/src/lib/types.ts
+++ b/apps/claude-profiles/src/lib/types.ts
@@ -144,7 +144,7 @@ export type QuotaUsage = {
   sevenDaySonnet: UsageWindow | null
 }
 
-export type QuotaError = 'no_credentials' | 'unauthorized' | 'network' | 'unknown'
+export type QuotaError = 'no_credentials' | 'unauthorized' | 'rate_limited' | 'network' | 'unknown'
 
 export type ProfileUsage = {
   quota: QuotaUsage | null

--- a/apps/claude-profiles/src/lib/types.ts
+++ b/apps/claude-profiles/src/lib/types.ts
@@ -132,3 +132,22 @@ export type AppMetadata = {
   homepage: string | null
   license: string | null
 }
+
+export type UsageWindow = {
+  utilization: number | null
+  resetsAt: string | null
+}
+
+export type QuotaUsage = {
+  fiveHour: UsageWindow | null
+  sevenDay: UsageWindow | null
+  sevenDaySonnet: UsageWindow | null
+}
+
+export type QuotaError = 'no_credentials' | 'unauthorized' | 'network' | 'unknown'
+
+export type ProfileUsage = {
+  quota: QuotaUsage | null
+  quotaError: QuotaError | null
+  fetchedAt: string
+}

--- a/apps/landing/src/components/usage-stats.astro
+++ b/apps/landing/src/components/usage-stats.astro
@@ -1,0 +1,25 @@
+---
+---
+<section
+  aria-labelledby="usage-stats-heading"
+  class="mx-auto max-w-[680px] px-4 pt-12 pb-4 sm:px-14"
+>
+  <h2
+    id="usage-stats-heading"
+    class="m-0 mb-[18px] text-[22px] font-semibold tracking-[-0.014em]"
+  >
+    See how much of your plan you've used
+  </h2>
+  <p class="m-0 mb-4 text-[15.5px] leading-[1.65] text-ink-soft">
+    Every profile shows its own Claude utilization right on the detail page — the
+    same numbers <code class="rounded bg-cream-2 px-1.5 py-px font-mono text-[0.88em]">/usage</code>
+    shows inside Claude Code, but visible at a glance alongside the launcher and
+    CLI buttons. Three meters: the rolling 5-hour window, the 7-day window, and
+    the 7-day Sonnet sub-window. Each meter shows a percentage and a relative
+    reset time.
+  </p>
+  <p class="m-0 text-[15.5px] leading-[1.65] text-ink-soft">
+    The card auto-refreshes every 5 minutes and tells you when the next refresh
+    will fire. Hit ↻ to refresh on demand.
+  </p>
+</section>

--- a/apps/landing/src/data/faq.ts
+++ b/apps/landing/src/data/faq.ts
@@ -33,4 +33,9 @@ export const faqEntries: ReadonlyArray<FaqEntry> = [
     answer:
       'Each profile gets its own Keychain entry, derived from the per-profile config directory. claude-profiles does not read or copy your credentials — Claude Code handles all of that itself. The isolation depends on undocumented Claude Code internals and could break in a future Claude Code release; if it does, we will patch.',
   },
+  {
+    question: 'How does the per-profile usage card work?',
+    answer:
+      "Each profile's detail page shows that profile's 5-hour, 7-day, and 7-day Sonnet utilization — the same numbers /usage shows inside Claude Code. The card reads the profile's OAuth token from its dedicated Keychain entry, calls Anthropic's /api/oauth/usage endpoint, and auto-refreshes every 5 minutes. The quota endpoint is undocumented Anthropic internals — same caveat as Keychain isolation — so the meters may render as dashes if the response shape changes.",
+  },
 ]

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -9,6 +9,7 @@ import InstallSection from '../components/install-section.astro'
 import MigrationExplainer from '../components/migration-explainer.astro'
 import TerminalStrip from '../components/terminal-strip.astro'
 import TopBar from '../components/top-bar.astro'
+import UsageStats from '../components/usage-stats.astro'
 import PageLayout from '../layouts/page.astro'
 ---
 
@@ -22,6 +23,7 @@ import PageLayout from '../layouts/page.astro'
     <AppScreenshot />
     <TerminalStrip />
     <HowItWorks />
+    <UsageStats />
     <MigrationExplainer />
     <InstallSection />
     <FaqSection />


### PR DESCRIPTION
## Summary

Adds per-profile Claude usage stats (5-hour and weekly quotas) to the profile detail view. Reads CLI credentials from disk (with macOS keychain fallback), fetches quota data from the Anthropic API, and renders meters with daily breakdown, on-pace marker, and a countdown to reset.

## What's new

- **Rust backend**
  - New `usage` module: credentials reader, quota HTTP client with defensive parsing, price table
  - Command wired into Tauri
  - macOS-only keychain lookup gated behind `cfg(target_os = "macos")`
  - Hardened quota fetch: explicit 4xx mapping, body size pre-check, token trim
  - Serialised + backed-off CLI token refresh; waits for token write
  - Auto-triggers Claude Code refresh on unauthorized quota fetch
- **Frontend**
  - `useProfileUsage` hook with defensive narrowing
  - Per-profile usage card on profile detail
  - Daily segments + on-pace marker on weekly meters
  - Countdown, equal-width bars, responsive labels
  - Explicit copy for every quota error state (unauthorized, 429, network, etc.)
  - Local breakdown stays visible when quota fetch fails
  - Usage cache isolated from profile invalidations; error boundary resets across profiles
- **Misc**
  - Renamed `useProfileUsage` → `useProfileLastUsed` to free up the name
  - ReactQueryDevtools button moved to bottom-right in dev
  - README + landing page updated

## Test plan

- Built locally on macOS, opened profile detail, verified meters render with live quota data
- Verified fallback when CLI is logged out, 429, network failure, and unauthorized states
- Verified countdown + on-pace marker behave correctly across profile switches
