### PR TITLE
ci(release-please): skip when latest release is still a draft

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,32 @@ jobs:
       tag_name: ${{ steps.release.outputs['apps/claude-profiles--tag_name'] }}
       sha: ${{ steps.release.outputs['apps/claude-profiles--sha'] }}
     steps:
+      # Guard against the race where release-please runs while the
+      # previous release's binaries are still building. During that
+      # window the latest GitHub release is still a draft, and
+      # release-please excludes drafts from its "latest release"
+      # baseline lookup — so it walks history from the previous
+      # published release and proposes a nonsensical version. See PR
+      # #19 retrospective. Skipping here lets the next push (or a
+      # manual workflow_dispatch after the build publishes the
+      # release) generate the correct release PR.
+      - name: Skip if latest release is still a draft
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --json tagName,isDraft -q '.[0]')
+          if [ -z "$latest" ]; then
+            echo "No releases yet — proceeding."
+            exit 0
+          fi
+          tag=$(echo "$latest" | jq -r .tagName)
+          is_draft=$(echo "$latest" | jq -r .isDraft)
+          if [ "$is_draft" = "true" ]; then
+            echo "::notice::Latest release $tag is still a draft (binaries still building?). Skipping release-please run."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # `token:` MUST be a PAT (or GitHub App token) — not the default
       # GITHUB_TOKEN. GitHub deliberately doesn't fire downstream
       # workflows for tags pushed under GITHUB_TOKEN, so release.yml
@@ -29,6 +55,7 @@ jobs:
       # bypasses that. See:
       # https://github.com/googleapis/release-please-action#github-credentials
       - id: release
+        if: steps.gate.outputs.skipped != 'true'
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Why

When a release PR is merged, two workflow runs trigger from that single push to `main`: release-please itself (~2 min), and the Tauri Release workflow (~7 min) that builds binaries, uploads them to the draft release, and flips the draft to published. The Release workflow normally publishes the draft *after* the second release-please run has already executed.

During that window the latest GitHub release is still a draft. release-please excludes drafts from its "latest release" baseline lookup, so it walks history from the previous *published* release and proposes a nonsense version — see [#19](https://github.com/bartekczyz/claude-profiles/pull/19) (proposed `v0.2.2` going backwards from `v0.4.0` after merging `v0.4.0`'s release PR).

## What

Adds a 16-line gate at the top of the `release-please` job that asks the GitHub API for the most recent release (including drafts) and exits early with a `::notice::` annotation when it's still a draft. The downstream `push-release-tag` job already gates on `release_created == 'true'`, which becomes empty when the step is skipped, so the tag push correctly no-ops too.

When the Release workflow finishes and publishes the draft, the next push to `main` (or a manual `workflow_dispatch`) sees a clean baseline and generates the correct release PR.

## Verification

- Pre-push hooks passed: typecheck, clippy, 151 cargo tests, landing vitest.
- Workflow YAML structure unchanged outside the new step.
- No-release case (`gh release list` returns empty) handled explicitly with an `exit 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
