### PR TITLE
fix: Default profile launch — open the stock app, single-instance per entry

### DIFF
--- a/apps/claude-profiles/src-tauri/Cargo.lock
+++ b/apps/claude-profiles/src-tauri/Cargo.lock
@@ -390,12 +390,15 @@ dependencies = [
 
 [[package]]
 name = "claude-profiles"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
  "dirs",
  "icns",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "plist",
  "reqwest 0.12.28",
  "serde",
@@ -2188,10 +2191,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2211,6 +2221,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2260,6 +2271,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,6 +2292,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2297,6 +2333,7 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-services",
 ]
 
 [[package]]
@@ -2332,6 +2369,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/apps/claude-profiles/src-tauri/Cargo.toml
+++ b/apps/claude-profiles/src-tauri/Cargo.toml
@@ -46,3 +46,16 @@ tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 
+# Focus / reopen a specific already-running Claude instance by PID
+# (single-instance launch behaviour). Already present transitively via tauri.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSRunningApplication"] }
+objc2-foundation = { version = "0.3", features = [
+    "NSAppleEventDescriptor",
+    "objc2-core-services",
+    "libc",
+    "NSDate",
+    "NSError",
+] }
+

--- a/apps/claude-profiles/src-tauri/src/commands.rs
+++ b/apps/claude-profiles/src-tauri/src/commands.rs
@@ -115,17 +115,25 @@ pub fn open_profile_in_app(id: String) -> AppResult<Profile> {
     if !profile.surfaces.gui {
         return Err(AppError::Validation("profile has no GUI surface".into()));
     }
+    // Single-instance gate: focus the profile's running window if there is
+    // one, otherwise launch via its `.app` bundle (which carries the tinted
+    // icon). The bundle's data dir matches the launcher script's
+    // `--user-data-dir`, so detection lines up with what actually runs.
+    let data_dir = profile_data_dir(&id)?.join("gui-data");
     let app_path = gui_launcher_path(&profile.name);
-    let status = Command::new("open")
-        .arg(&app_path)
-        .status()
-        .map_err(AppError::Io)?;
-    if !status.success() {
-        return Err(AppError::Validation(format!(
-            "`open {}` exited with status {status}",
-            app_path.display()
-        )));
-    }
+    crate::launch::focus_or_launch(&data_dir.display().to_string(), || {
+        let status = Command::new("open")
+            .arg(&app_path)
+            .status()
+            .map_err(AppError::Io)?;
+        if !status.success() {
+            return Err(AppError::Validation(format!(
+                "`open {}` exited with status {status}",
+                app_path.display()
+            )));
+        }
+        Ok(())
+    })?;
     record_silent(&id, ActivityKind::LaunchedGui, None);
     profiles::touch_last_used(&id)
 }
@@ -149,27 +157,21 @@ pub fn open_in_finder(path: String) -> AppResult<()> {
     Ok(())
 }
 
-/// Launch an application bundle by its path using macOS's `open` command.
+/// Launch — or focus, if already running — the stock Claude desktop app bound
+/// to a specific `--user-data-dir`.
 ///
-/// Unlike `open_profile_in_app`, this operates on the pre-resolved path
-/// rather than a managed-profile ID, so it works for the default Claude
-/// entry whose launcher lives at the detected system path.
+/// This is the default entry's counterpart to `open_profile_in_app`. It has no
+/// launcher `.app` bundle of its own, so it shells out to the same incantation
+/// those bundles use (`open -n -a "Claude" --args --user-data-dir=...`), just
+/// pointed at the stock data directory.
+///
+/// `focus_or_launch` provides the single-instance guarantee: Claude does not
+/// dedupe by data dir (a bare `open -n` would spawn an unbounded number of
+/// stock windows), so we detect an existing instance ourselves and focus it
+/// instead of launching another.
 #[tauri::command]
-pub fn open_app(path: String) -> AppResult<()> {
-    let target = std::path::Path::new(&path);
-    if !target.exists() {
-        return Err(AppError::NotFound(format!("path does not exist: {path}")));
-    }
-    let status = Command::new("open")
-        .arg(&path)
-        .status()
-        .map_err(AppError::Io)?;
-    if !status.success() {
-        return Err(AppError::Validation(format!(
-            "`open {path}` exited with status {status}"
-        )));
-    }
-    Ok(())
+pub fn open_claude_gui(data_dir: String) -> AppResult<()> {
+    crate::launch::focus_or_launch(&data_dir, || crate::launch::open_new_instance(&data_dir))
 }
 
 #[tauri::command]

--- a/apps/claude-profiles/src-tauri/src/deps.rs
+++ b/apps/claude-profiles/src-tauri/src/deps.rs
@@ -75,7 +75,7 @@ pub fn find_claude_in_path(path_string: &str, home: &Path) -> bool {
 }
 
 pub fn claude_app_exists() -> bool {
-    PathBuf::from("/Applications/Claude.app").is_dir()
+    crate::paths::claude_desktop_app_bundle().is_dir()
 }
 
 fn get_shell_path() -> Option<String> {

--- a/apps/claude-profiles/src-tauri/src/launch.rs
+++ b/apps/claude-profiles/src-tauri/src/launch.rs
@@ -1,0 +1,201 @@
+//! Single-instance launch handling for the Claude desktop app.
+//!
+//! Claude does NOT enforce one instance per data directory: `open -n` always
+//! spawns a brand-new process, and two instances happily share the same
+//! `--user-data-dir`. To give each entry (the stock default and every managed
+//! profile) "exactly one window, all coexisting" behaviour, we track the
+//! running instances ourselves: before launching we scan for a main Claude
+//! process already bound to the target data dir, and focus it instead of
+//! spawning a duplicate.
+
+use std::process::Command;
+
+use crate::error::{AppError, AppResult};
+
+/// Find the PID of the *main* Claude process bound to `data_dir` in `ps`
+/// output, or `None`.
+///
+/// Every running instance is one `…/Contents/MacOS/Claude
+/// --user-data-dir=<dir>` process. Helper processes (renderer, GPU, network,
+/// …) carry the same flag, but they run a different executable
+/// (`…/MacOS/Claude Helper`) and always have trailing arguments. Requiring the
+/// line to end with `…/Contents/MacOS/Claude --user-data-dir=<dir>` therefore
+/// matches only the main process and rejects helpers, the crashpad handler,
+/// and instances bound to any other data dir.
+pub fn find_running_claude_pid(ps_output: &str, data_dir: &str) -> Option<i32> {
+    let suffix = format!("/Contents/MacOS/Claude --user-data-dir={data_dir}");
+    for line in ps_output.lines() {
+        let Some((pid, command)) = line.trim_start().split_once(char::is_whitespace) else {
+            continue;
+        };
+        if command.trim_end().ends_with(&suffix) {
+            if let Ok(parsed) = pid.parse::<i32>() {
+                return Some(parsed);
+            }
+        }
+    }
+    None
+}
+
+/// Scan running processes for a main Claude bound to `data_dir`.
+fn running_claude_pid(data_dir: &str) -> AppResult<Option<i32>> {
+    let output = Command::new("ps")
+        .args(["-ax", "-o", "pid=,command="])
+        .output()
+        .map_err(AppError::Io)?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(find_running_claude_pid(&stdout, data_dir))
+}
+
+/// Surface the already-running instance that owns `pid`: ask it to reopen a
+/// window, then bring it to the foreground.
+///
+/// The reopen step matters because closing a Claude window does not quit the
+/// app on macOS — the process keeps running with no windows. Plain activation
+/// would bring that windowless process forward but show nothing. Sending it
+/// the `reopen` Apple event (`aevt`/`rapp`) — exactly what clicking the Dock
+/// icon does — makes it recreate its window. Addressing the event to a
+/// specific PID keeps it scoped to the right instance even when several Claude
+/// processes (other profiles) are running under the shared bundle id.
+///
+/// Best-effort: a missing process or a refused step is ignored — the caller
+/// has already decided not to spawn a duplicate.
+#[cfg(target_os = "macos")]
+fn focus_pid(pid: i32) {
+    use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
+    use objc2_foundation::{NSAppleEventDescriptor, NSAppleEventSendOptions};
+
+    // 'aevt'/'rapp' — the standard reopen-application event. Reopen is exempt
+    // from the Automation (TCC) consent prompt, so this is silent.
+    const CORE_EVENT_CLASS: u32 = u32::from_be_bytes(*b"aevt");
+    const REOPEN_APPLICATION: u32 = u32::from_be_bytes(*b"rapp");
+    const AUTO_GENERATE_RETURN_ID: i16 = -1;
+    const ANY_TRANSACTION_ID: i32 = 0;
+    const TIMEOUT_SECONDS: f64 = 5.0;
+
+    let target = NSAppleEventDescriptor::descriptorWithProcessIdentifier(pid);
+    let reopen = NSAppleEventDescriptor::appleEventWithEventClass_eventID_targetDescriptor_returnID_transactionID(
+        CORE_EVENT_CLASS,
+        REOPEN_APPLICATION,
+        Some(&target),
+        AUTO_GENERATE_RETURN_ID,
+        ANY_TRANSACTION_ID,
+    );
+    let _ = reopen
+        .sendEventWithOptions_timeout_error(NSAppleEventSendOptions::NoReply, TIMEOUT_SECONDS);
+
+    // Activating another application requires no entitlement and triggers no
+    // TCC prompt.
+    #[allow(deprecated)]
+    if let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) {
+        app.activateWithOptions(NSApplicationActivationOptions::ActivateIgnoringOtherApps);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn focus_pid(_pid: i32) {}
+
+/// Focus the running Claude bound to `data_dir`, or run `launch` when none is
+/// running. This is the single-instance gate shared by the default entry and
+/// the managed profiles.
+pub fn focus_or_launch<F>(data_dir: &str, launch: F) -> AppResult<()>
+where
+    F: FnOnce() -> AppResult<()>,
+{
+    if let Some(pid) = running_claude_pid(data_dir)? {
+        focus_pid(pid);
+        return Ok(());
+    }
+    launch()
+}
+
+/// Launch a fresh Claude instance bound to `data_dir` via
+/// `open -n -a "Claude" --args --user-data-dir=<dir>` — the same incantation
+/// the per-profile launcher `.app` bundles use, just invoked directly. Used
+/// by the default entry, which has no launcher bundle of its own.
+pub fn open_new_instance(data_dir: &str) -> AppResult<()> {
+    let status = Command::new("open")
+        .arg("-n")
+        .arg("-a")
+        .arg("Claude")
+        .arg("--args")
+        .arg(format!("--user-data-dir={data_dir}"))
+        .status()
+        .map_err(AppError::Io)?;
+    if !status.success() {
+        return Err(AppError::Validation(format!(
+            "`open -n -a Claude --args --user-data-dir={data_dir}` exited with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STOCK_DIR: &str = "/Users/me/Library/Application Support/Claude";
+    const PROFILE_DIR: &str =
+        "/Users/me/Library/Application Support/claude-profiles/profiles/abc/gui-data";
+
+    /// Mirrors real `ps -ax -o pid=,command=` output: leading-padded PIDs, a
+    /// main process per instance, and helper/crashpad lines that also carry
+    /// `--user-data-dir` but must NOT match.
+    fn sample_ps() -> String {
+        format!(
+            "\
+  54587 /Applications/Claude.app/Contents/MacOS/Claude --user-data-dir={STOCK_DIR}
+  56318 /Applications/Claude.app/Contents/MacOS/Claude --user-data-dir={PROFILE_DIR}
+  54590 /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=gpu-process --user-data-dir={STOCK_DIR} --gpu-preferences=xyz
+   1866 /Applications/Claude.app/Contents/Frameworks/Electron Framework.framework/Helpers/chrome_crashpad_handler --database={STOCK_DIR}/Crashpad --handshake-fd=18
+"
+        )
+    }
+
+    #[test]
+    fn matches_main_process_for_the_stock_data_dir() {
+        assert_eq!(
+            find_running_claude_pid(&sample_ps(), STOCK_DIR),
+            Some(54587)
+        );
+    }
+
+    #[test]
+    fn matches_main_process_for_a_profile_data_dir() {
+        assert_eq!(
+            find_running_claude_pid(&sample_ps(), PROFILE_DIR),
+            Some(56318)
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_instance_is_bound_to_the_dir() {
+        let other = "/Users/me/Library/Application Support/claude-profiles/profiles/zzz/gui-data";
+        assert_eq!(find_running_claude_pid(&sample_ps(), other), None);
+    }
+
+    #[test]
+    fn ignores_helper_processes_that_share_the_data_dir() {
+        // A renderer/GPU helper carries --user-data-dir but is not the main
+        // process; if only helpers were running we must report nothing.
+        let helpers_only = format!(
+            "  54590 /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=renderer --user-data-dir={STOCK_DIR} --enable-sandbox\n"
+        );
+        assert_eq!(find_running_claude_pid(&helpers_only, STOCK_DIR), None);
+    }
+
+    #[test]
+    fn does_not_let_the_stock_dir_match_a_profile_whose_path_extends_it() {
+        // The stock dir is a path prefix of nothing here, but guard the
+        // reverse: searching the stock dir must not match the longer profile
+        // line, and vice versa.
+        assert_ne!(
+            find_running_claude_pid(&sample_ps(), STOCK_DIR),
+            Some(56318)
+        );
+        assert_ne!(
+            find_running_claude_pid(&sample_ps(), PROFILE_DIR),
+            Some(54587)
+        );
+    }
+}

--- a/apps/claude-profiles/src-tauri/src/lib.rs
+++ b/apps/claude-profiles/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod app_state;
 mod commands;
 mod deps;
 mod error;
+mod launch;
 mod launchers;
 mod migration;
 mod path_setup;
@@ -99,7 +100,7 @@ pub fn run() {
             commands::toggle_surface,
             commands::open_profile_in_app,
             commands::open_in_finder,
-            commands::open_app,
+            commands::open_claude_gui,
             commands::profile_paths,
             commands::detect_existing_claude_install,
             commands::detect_existing_claude_sizes,

--- a/apps/claude-profiles/src-tauri/src/paths.rs
+++ b/apps/claude-profiles/src-tauri/src/paths.rs
@@ -68,6 +68,14 @@ pub fn gui_launcher_path(name: &str) -> PathBuf {
     applications_dir().join(format!("Claude ({name}).app"))
 }
 
+/// Path to the stock (unmanaged) Claude desktop application bundle. This is
+/// the app the synthetic "default" entry launches — distinct from
+/// `claude_desktop_install_path`, which points at the app's *data* directory
+/// under `~/Library/Application Support`.
+pub fn claude_desktop_app_bundle() -> PathBuf {
+    applications_dir().join("Claude.app")
+}
+
 pub fn local_bin_dir() -> AppResult<PathBuf> {
     let home = dirs::home_dir()
         .ok_or_else(|| AppError::NotFound("could not determine user home directory".to_string()))?;
@@ -125,6 +133,14 @@ mod tests {
     fn gui_launcher_path_handles_names_with_special_chars() {
         let path = gui_launcher_path("Acme & Co");
         assert_eq!(path, PathBuf::from("/Applications/Claude (Acme & Co).app"));
+    }
+
+    #[test]
+    fn claude_desktop_app_bundle_points_to_applications_bundle() {
+        assert_eq!(
+            claude_desktop_app_bundle(),
+            PathBuf::from("/Applications/Claude.app")
+        );
     }
 
     #[test]

--- a/apps/claude-profiles/src-tauri/src/profiles.rs
+++ b/apps/claude-profiles/src-tauri/src/profiles.rs
@@ -413,9 +413,10 @@ pub fn touch_last_used(id: &str) -> AppResult<Profile> {
 fn default_claude_paths() -> AppResult<ProfilePaths> {
     let home =
         dirs::home_dir().ok_or_else(|| AppError::Io(std::io::Error::other("no home dir")))?;
-    let desktop_path = crate::paths::claude_desktop_install_path()?;
-    let code_path = crate::paths::claude_code_install_path()?;
-    let existing = crate::migration::detect(&desktop_path, &code_path);
+    // The default entry launches the stock Claude.app bundle, not its data
+    // directory. Resolve to the application bundle and expose it only when it
+    // exists so "Open Claude" / "Launcher" act on a launchable app.
+    let app_bundle = crate::paths::claude_desktop_app_bundle();
     Ok(ProfilePaths {
         data_dir: home.join(".claude").display().to_string(),
         gui_data_dir: home
@@ -423,7 +424,9 @@ fn default_claude_paths() -> AppResult<ProfilePaths> {
             .display()
             .to_string(),
         cli_config_dir: home.join(".claude").display().to_string(),
-        gui_launcher_path: existing.claude_desktop_path,
+        gui_launcher_path: app_bundle
+            .is_dir()
+            .then(|| app_bundle.display().to_string()),
         cli_wrapper_path: None,
     })
 }
@@ -473,8 +476,20 @@ mod tests {
             .gui_data_dir
             .ends_with("/Library/Application Support/Claude"));
         assert!(paths.cli_wrapper_path.is_none(), "default has no wrapper");
-        // gui_launcher_path is Some only if stock Claude.app is installed;
-        // don't assert on it because the test host may or may not have it.
+        // gui_launcher_path is Some only if stock Claude.app is installed, so
+        // don't require a value (the test host may lack it). But when present
+        // it must be the launchable .app bundle, never the data directory —
+        // otherwise "Open Claude" just reveals a folder in Finder.
+        if let Some(launcher) = &paths.gui_launcher_path {
+            assert_ne!(
+                launcher, &paths.gui_data_dir,
+                "launcher must not be the data directory"
+            );
+            assert!(
+                launcher.ends_with(".app"),
+                "launcher must be an .app bundle"
+            );
+        }
     }
 
     #[test]

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-default.test.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-default.test.tsx
@@ -34,7 +34,7 @@ vi.mock('@/lib/commands', async () => {
       localBinOnPath: true,
     })),
     openInFinder: vi.fn(async () => {}),
-    openApp: vi.fn(async () => {}),
+    openClaudeGui: vi.fn(async () => {}),
     copyToClipboard: vi.fn(async () => {}),
   }
 })

--- a/apps/claude-profiles/src/features/profiles/components/profile-detail-default.tsx
+++ b/apps/claude-profiles/src/features/profiles/components/profile-detail-default.tsx
@@ -2,7 +2,7 @@ import type { DefaultEntry } from '@/lib/types'
 
 import { Suspense, useState } from 'react'
 
-import { copyToClipboard, openApp } from '@/lib/commands'
+import { copyToClipboard, openClaudeGui } from '@/lib/commands'
 
 import { useProfilePaths } from '../api/use-profile-paths'
 import { OutlinedSwatch } from './outlined-swatch'
@@ -62,7 +62,7 @@ function DefaultSurfaceCards({ entry, onError }: DefaultSurfaceCardsProps) {
         if (paths.guiLauncherPath === null) {
           return
         }
-        await openApp(paths.guiLauncherPath)
+        await openClaudeGui(paths.guiDataDir)
       }}
       onCopyCli={async () => {
         await copyToClipboard('claude')

--- a/apps/claude-profiles/src/lib/commands.ts
+++ b/apps/claude-profiles/src/lib/commands.ts
@@ -66,8 +66,8 @@ export function openInFinder(path: string): Promise<void> {
   return invoke('open_in_finder', { path })
 }
 
-export function openApp(path: string): Promise<void> {
-  return invoke('open_app', { path })
+export function openClaudeGui(dataDir: string): Promise<void> {
+  return invoke('open_claude_gui', { dataDir })
 }
 
 export function profilePaths(id: string): Promise<ProfilePaths> {


### PR DESCRIPTION
## Problem

Launching Claude from the **Default** entry was broken in several ways (all reported while testing):

1. **Open Claude / Reveal app / Launcher** all just opened a Finder window at `~/Library/Application Support/Claude` instead of running the app.
2. Once that was fixed, **Open Claude** would *focus an already-running profile* instead of launching the default app.
3. Then it would spawn an **unbounded number of instances** on every click.
4. And when an instance's window was closed (app still running, Dock dot showing), clicking **Open Claude** did nothing.

## Root causes

- `default_claude_paths` resolved `gui_launcher_path` to the app's **data directory**, not the `Claude.app` **bundle**.
- macOS resolves a plain `open`/activation by **bundle id** — every Claude instance shares one, so it can't target a specific one.
- Claude does **not** enforce one instance per `--user-data-dir`; `open -n` always spawns a new process (verified empirically).
- Closing a window doesn't quit the app; plain activation brings the windowless process forward but never recreates a window.

## Fix

Two commits:

1. **Resolve the Default launcher to `/Applications/Claude.app`** (present only when installed), via a shared `claude_desktop_app_bundle()` helper.
2. **Track instances ourselves** (`launch.rs`): before launching, find the main `…/MacOS/Claude --user-data-dir=<dir>` process. If it exists, send it a **PID-targeted `reopen` Apple event** (recreates the window, exactly like a Dock-icon click — no permission prompt) and activate it. Otherwise launch. Applied to both the Default entry and every managed profile.

Result: each entry (default + every profile) opens **exactly once**, all coexist, and a closed window reopens for the right instance.

## Testing

- New pure unit tests for the `ps`-output parser (matches the main process, rejects helpers/crashpad/other dirs); detection also validated against the live process table.
- Reopen-by-PID and activation verified against running Claude instances (no TCC prompt, no duplicate spawned).
- Full suite green: 168 Rust tests, 8 frontend tests, clippy + rustfmt + tsc clean.

## Known follow-up

Double-clicking a profile's launcher `.app` directly from Finder/Dock still bypasses this gate (its bundled script does a bare `open -n`). Making the launcher script itself single-instance requires regenerating existing launchers — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)