### PR TITLE
fix(usage): fix daily profile logouts — working token refresh, safer polling, clearer recovery

### DIFF
--- a/apps/ai-profiles/src-tauri/Cargo.lock
+++ b/apps/ai-profiles/src-tauri/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "plist",
+ "portable-pty",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -397,6 +398,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -840,7 +847,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -917,6 +924,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1911,6 +1929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2150,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -2639,6 +2675,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,7 +2825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2808,7 +2865,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -3413,6 +3470,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3453,6 +3521,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -5522,6 +5606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/apps/ai-profiles/src-tauri/Cargo.toml
+++ b/apps/ai-profiles/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-clipboard-manager = "2"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "gzip", "brotli", "deflate"] }
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "macros", "process", "time"] }
+portable-pty = "0.9.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/apps/ai-profiles/src-tauri/src/commands.rs
+++ b/apps/ai-profiles/src-tauri/src/commands.rs
@@ -219,6 +219,57 @@ pub fn open_external_url(url: String) -> AppResult<()> {
     Ok(())
 }
 
+/// Opens the profile's CLI in a new Terminal window so the user can sign in
+/// again (`/login`). Used by the usage card when a token can't be refreshed:
+/// running the wrapper interactively is what rotates+persists the credential.
+///
+/// We resolve the command server-side (the per-profile wrapper `claude-<slug>`,
+/// or the stock binary for the default entry) rather than trusting a string
+/// from the frontend, then hand it to Terminal via `osascript`.
+#[tauri::command]
+pub fn open_cli_login(id: String) -> AppResult<()> {
+    let all = profiles::load()?;
+    let command = cli_login_command(&id, &all)?;
+    let script = terminal_applescript(&command);
+    let status = Command::new("/usr/bin/osascript")
+        .arg("-e")
+        .arg(&script)
+        .status()
+        .map_err(AppError::Io)?;
+    if !status.success() {
+        return Err(AppError::Validation(format!(
+            "osascript exited with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Pure: the interactive CLI command for a profile entry — the per-profile
+/// wrapper (`claude-<slug>`) for managed profiles, or the stock binary
+/// (`claude` / `codex`) for the default entry.
+fn cli_login_command(id: &str, profiles: &[Profile]) -> AppResult<String> {
+    if let Some(kind) = AppKind::from_default_id(id) {
+        return Ok(spec(kind).cli_binary.to_string());
+    }
+    let profile = profiles
+        .iter()
+        .find(|candidate| candidate.id == id)
+        .ok_or_else(|| AppError::NotFound(format!("profile {id} not found")))?;
+    Ok(format!(
+        "{}-{}",
+        profile.app.spec().cli_wrapper_prefix,
+        profile.slug
+    ))
+}
+
+/// Pure: AppleScript that opens a new Terminal window running `command` and
+/// brings Terminal to the foreground. `command` is escaped for the AppleScript
+/// string literal — defensive only; profile slugs are already a safe charset.
+fn terminal_applescript(command: &str) -> String {
+    let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("tell application \"Terminal\"\n    activate\n    do script \"{escaped}\"\nend tell")
+}
+
 #[tauri::command]
 pub fn list_activity(profile_id: String, limit: usize) -> AppResult<Vec<Activity>> {
     let path = activity_log_path(&profile_id)?;
@@ -555,5 +606,69 @@ mod usage_routing_tests {
     fn resolve_cli_config_dir_for_managed_id_is_per_profile() {
         let resolved = resolve_cli_config_dir("some-managed-id").expect("ok");
         assert!(resolved.ends_with("cli-config"));
+    }
+}
+
+#[cfg(test)]
+mod cli_login_tests {
+    use super::*;
+
+    fn managed(id: &str, app: AppKind, slug: &str) -> Profile {
+        Profile {
+            id: id.into(),
+            app,
+            name: "X".into(),
+            slug: slug.into(),
+            color: "#000000".into(),
+            created_at: "2026-06-14T00:00:00Z".into(),
+            surfaces: Surfaces {
+                gui: false,
+                cli: true,
+            },
+            last_used_at: None,
+        }
+    }
+
+    #[test]
+    fn cli_login_command_uses_the_wrapper_for_a_managed_profile() {
+        let profiles = vec![managed("abc", AppKind::Claude, "personal")];
+        assert_eq!(
+            cli_login_command("abc", &profiles).unwrap(),
+            "claude-personal"
+        );
+    }
+
+    #[test]
+    fn cli_login_command_uses_the_codex_prefix_for_a_codex_profile() {
+        let profiles = vec![managed("xyz", AppKind::Codex, "work")];
+        assert_eq!(cli_login_command("xyz", &profiles).unwrap(), "codex-work");
+    }
+
+    #[test]
+    fn cli_login_command_uses_the_stock_binary_for_default_entries() {
+        assert_eq!(cli_login_command("default:claude", &[]).unwrap(), "claude");
+        assert_eq!(cli_login_command("default:codex", &[]).unwrap(), "codex");
+    }
+
+    #[test]
+    fn cli_login_command_is_not_found_for_an_unknown_id() {
+        assert!(matches!(
+            cli_login_command("nope", &[]).unwrap_err(),
+            AppError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn terminal_applescript_runs_the_command_and_activates() {
+        let script = terminal_applescript("claude-personal");
+        assert!(script.contains(r#"do script "claude-personal""#));
+        assert!(script.contains("activate"));
+    }
+
+    #[test]
+    fn terminal_applescript_escapes_quotes_and_backslashes() {
+        // Defensive: a stray quote must not break out of the string literal.
+        let script = terminal_applescript(r#"a"b\c"#);
+        assert!(script.contains(r#"do script "a\"b\\c""#));
     }
 }

--- a/apps/ai-profiles/src-tauri/src/lib.rs
+++ b/apps/ai-profiles/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             commands::get_app_metadata,
             commands::get_profile_usage,
             commands::open_external_url,
+            commands::open_cli_login,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/ai-profiles/src-tauri/src/usage/mod.rs
+++ b/apps/ai-profiles/src-tauri/src/usage/mod.rs
@@ -35,6 +35,10 @@ pub struct Window {
 pub enum QuotaError {
     NoCredentials,
     Unauthorized,
+    /// HTTP 403 from the usage endpoint. In practice an edge/WAF policy
+    /// block (Cloudflare), not bad credentials — must never trigger a CLI
+    /// refresh spawn or a dead-credential mark.
+    Forbidden,
     /// Stored credentials are dead and cannot be auto-refreshed — the user
     /// must sign in to this profile again. Distinct from the transient
     /// `Unauthorized`, which a CLI refresh can fix.
@@ -352,6 +356,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn refresh_is_not_triggered_for_forbidden() {
+        let dir = dir_with_token();
+        let provider = QueuedProvider::new(vec![Err(QuotaError::Forbidden)]);
+        let refresher = RecordingRefresher::new();
+        let registry = dead_credentials::DeadCredentialRegistry::new();
+        let result = build_with_cli_refresh(dir.path(), &provider, &refresher, &registry).await;
+        assert!(matches!(result.quota_error, Some(QuotaError::Forbidden)));
+        assert_eq!(refresher.call_count(), 0);
+    }
+
+    #[tokio::test]
     async fn refresh_recovers_when_token_rotates() {
         let dir = dir_with_token();
         // First call: Unauthorized; the refresh rotates the token; retry succeeds.
@@ -464,6 +479,13 @@ mod tests {
         // Wire contract: the frontend QuotaError union expects `needs_login`.
         let json = serde_json::to_string(&QuotaError::NeedsLogin).unwrap();
         assert_eq!(json, "\"needs_login\"");
+    }
+
+    #[test]
+    fn forbidden_serializes_to_snake_case() {
+        // Wire contract: the frontend QuotaError union expects `forbidden`.
+        let json = serde_json::to_string(&QuotaError::Forbidden).unwrap();
+        assert_eq!(json, "\"forbidden\"");
     }
 
     #[test]

--- a/apps/ai-profiles/src-tauri/src/usage/quota.rs
+++ b/apps/ai-profiles/src-tauri/src/usage/quota.rs
@@ -191,7 +191,11 @@ pub async fn fetch_quota_cached(
 fn parse_response(response: HttpResponse) -> Result<QuotaUsage, QuotaError> {
     match response.status {
         200 => parse_body(&response.body),
-        401 | 403 => Err(QuotaError::Unauthorized),
+        401 => Err(QuotaError::Unauthorized),
+        // 403 is typically an edge/WAF policy block in front of the
+        // endpoint, not an auth problem — mapping it to Unauthorized
+        // would tell the user to re-auth for a transient block.
+        403 => Err(QuotaError::Forbidden),
         429 => Err(QuotaError::RateLimited),
         500..=599 => Err(QuotaError::Network),
         // Other 4xx (400 bad request, 404 endpoint moved, 410 gone, …)
@@ -486,7 +490,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forbidden_status_maps_to_unauthorized() {
+    async fn forbidden_status_maps_to_forbidden() {
+        // 403 here is typically an edge/WAF policy block, not bad credentials.
+        // It must NOT map to Unauthorized — that would trigger a refresh spawn
+        // that churns the single-use refresh token for nothing.
         let dir = dir_with_token();
         let client = StubClient {
             status: 403,
@@ -494,7 +501,7 @@ mod tests {
         };
         assert!(matches!(
             fetch_quota(dir.path(), &client).await.unwrap_err(),
-            QuotaError::Unauthorized,
+            QuotaError::Forbidden,
         ));
     }
 

--- a/apps/ai-profiles/src-tauri/src/usage/refresh.rs
+++ b/apps/ai-profiles/src-tauri/src/usage/refresh.rs
@@ -1,6 +1,6 @@
-//! Triggers Claude Code's built-in OAuth token refresh by spawning the
-//! `claude` binary as a subprocess with the profile's `CLAUDE_CONFIG_DIR`
-//! set and stdin closed.
+//! Triggers Claude Code's built-in OAuth token refresh by driving a real
+//! interactive `claude` session under a pseudo-terminal far enough that it
+//! rotates and persists its own token, then exiting.
 //!
 //! ## Why we delegate to Claude Code instead of refreshing ourselves
 //!
@@ -10,30 +10,50 @@
 //! the refresh token and a `client_id` — neither of which is publicly
 //! documented. Reverse-engineering them would couple us to undocumented
 //! internals that can change without notice. Delegating to Claude Code
-//! itself sidesteps that entire problem: when invoked it silently
-//! refreshes its own token using its own knowledge of those endpoints.
+//! itself sidesteps that entire problem: when invoked interactively it
+//! silently refreshes its own token using its own knowledge of those
+//! endpoints, and — unlike `claude -p` — *persists* the rotated refresh
+//! token back to the keychain.
 //!
-//! ## How the spawn works
+//! ## Why a pseudo-terminal, and why a prompt
 //!
-//! `claude < /dev/null > /dev/null 2>&1` exits cleanly within a few
-//! hundred milliseconds — the REPL detects EOF on stdin during its
-//! startup pass and exits before showing a prompt. The auth refresh
-//! happens early in that startup pass, before stdin is read. We bound
-//! the wait at 8s (matching the quota fetch timeout) and `kill_on_drop`
-//! ensures the child is reaped if our timeout fires.
+//! With a plain piped / `/dev/null` stdin, claude detects "no TTY" and treats
+//! the invocation as `--print` mode, exiting with a usage error *before any
+//! auth work*. So a non-pty spawn never refreshes anything. We allocate a real
+//! pty (via `portable-pty`, so we own claude's pid and can reap it cleanly —
+//! no orphaned children), wait for the REPL to finish starting, then send a
+//! trivial prompt. The prompt forces an API interaction, which is what
+//! reliably triggers the refresh + persist. We then wait (bounded by
+//! [`REFRESH_TIMEOUT`]) for the stored token to change, send `/exit`, and kill
+//! the child. Success is verified by the caller re-reading the token, never by
+//! the child's exit status.
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use tokio::sync::Mutex as TokioMutex;
 
-/// How long we'll wait for the spawned `claude` to finish refreshing
-/// its token before giving up. Matches the quota fetch timeout.
-const REFRESH_TIMEOUT: Duration = Duration::from_secs(8);
+/// How long we'll wait for the spawned `claude` to persist a refreshed token
+/// before giving up. Generous: a refresh behind a slow network can take a few
+/// seconds, and the child is reaped cleanly either way.
+const REFRESH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Quiet stretch with no new pty output that we take to mean the REPL has
+/// finished starting and is ready for input. Sending the prompt earlier would
+/// lose it into a not-yet-ready readline.
+const SETTLE_QUIET: Duration = Duration::from_millis(500);
+
+/// Ceiling on how long we wait for the REPL to settle before sending the
+/// prompt anyway.
+const SETTLE_CAP: Duration = Duration::from_secs(10);
+
+/// How often we re-read the credential while waiting for the refresh to land.
+const ROTATE_POLL: Duration = Duration::from_millis(150);
 
 /// After a refresh attempt completes, skip further attempts for the
 /// same profile inside this window. Without this, a profile whose
@@ -132,7 +152,6 @@ async fn spawn_claude(cli_config_dir: &Path) {
     let Some(binary) = find_claude_binary() else {
         return;
     };
-    let mut command = tokio::process::Command::new(&binary);
     // For the stock default profile we deliberately do NOT set
     // CLAUDE_CONFIG_DIR. Setting it — even to its implicit default
     // (`$HOME/.claude`) — flips Claude Code's keychain layout from the
@@ -140,20 +159,112 @@ async fn spawn_claude(cli_config_dir: &Path) {
     // `Claude Code-credentials-<sha256(dir)[:8]>` form. The refreshed
     // token would land in the hashed entry while we keep reading from
     // bare, leaving the next quota fetch unauthorised again.
-    if !crate::usage::is_stock_default_cli_config_dir(cli_config_dir) {
-        command.env("CLAUDE_CONFIG_DIR", cli_config_dir);
+    let set_config = !crate::usage::is_stock_default_cli_config_dir(cli_config_dir);
+    let dir = cli_config_dir.to_path_buf();
+    // `portable-pty` is blocking; run the whole dance off the async runtime.
+    let _ = tokio::task::spawn_blocking(move || run_pty_refresh(&binary, &dir, set_config)).await;
+}
+
+/// Pure: true once the pty has produced output and then gone quiet for
+/// [`SETTLE_QUIET`], or the [`SETTLE_CAP`] ceiling has been reached. Used to
+/// decide when the REPL is ready to receive the prompt.
+fn prompt_is_ready(saw_output: bool, quiet_for: Duration, settle_elapsed: Duration) -> bool {
+    if settle_elapsed >= SETTLE_CAP {
+        return true;
     }
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .kill_on_drop(true);
-    let Ok(mut child) = command.spawn() else {
+    saw_output && quiet_for >= SETTLE_QUIET
+}
+
+/// Drives a real interactive `claude` under a pty far enough to refresh +
+/// persist its token, then exits. Best-effort: any failure just returns, and
+/// the caller verifies success by re-reading the credential.
+fn run_pty_refresh(binary: &Path, cli_config_dir: &Path, set_config: bool) {
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+    let Ok(pair) = native_pty_system().openpty(PtySize {
+        rows: 40,
+        cols: 120,
+        pixel_width: 0,
+        pixel_height: 0,
+    }) else {
         return;
     };
-    // We don't care about the exit status. If the timeout fires, the
-    // future is dropped and `kill_on_drop` reaps the child.
-    let _ = tokio::time::timeout(REFRESH_TIMEOUT, child.wait()).await;
+    let portable_pty::PtyPair { master, slave } = pair;
+
+    let mut cmd = CommandBuilder::new(binary);
+    if set_config {
+        cmd.env("CLAUDE_CONFIG_DIR", cli_config_dir);
+    }
+    if let Some(home) = dirs::home_dir() {
+        cmd.cwd(home);
+    }
+
+    let Ok(mut child) = slave.spawn_command(cmd) else {
+        return;
+    };
+    // The child holds the slave fd now; drop ours so EOF propagates on exit.
+    drop(slave);
+
+    let (Ok(mut reader), Ok(mut writer)) = (master.try_clone_reader(), master.take_writer()) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return;
+    };
+
+    // Drain output on a thread — an unread pty fills its buffer and stalls the
+    // child — while tracking when the last byte arrived so we can tell when
+    // startup has settled.
+    let last_byte = Arc::new(StdMutex::new(Instant::now()));
+    let saw_output = Arc::new(AtomicBool::new(false));
+    {
+        let last_byte = Arc::clone(&last_byte);
+        let saw_output = Arc::clone(&saw_output);
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            while let Ok(read) = reader.read(&mut buf) {
+                if read == 0 {
+                    break;
+                }
+                *last_byte.lock().unwrap() = Instant::now();
+                saw_output.store(true, Ordering::SeqCst);
+            }
+        });
+    }
+
+    // Wait for the REPL to settle before sending the prompt.
+    let settle_start = Instant::now();
+    while !prompt_is_ready(
+        saw_output.load(Ordering::SeqCst),
+        last_byte.lock().unwrap().elapsed(),
+        settle_start.elapsed(),
+    ) {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // A trivial prompt forces an API interaction → claude refreshes + persists
+    // its token. `\r` is Enter inside a TTY.
+    let token_before = crate::usage::credentials::read_access_token(cli_config_dir).ok();
+    let _ = writer.write_all(b"hi\r");
+    let _ = writer.flush();
+
+    // Wait (bounded) for the persisted token to change.
+    let rotate_deadline = Instant::now() + REFRESH_TIMEOUT;
+    loop {
+        let current = crate::usage::credentials::read_access_token(cli_config_dir).ok();
+        if current != token_before || Instant::now() >= rotate_deadline {
+            break;
+        }
+        std::thread::sleep(ROTATE_POLL);
+    }
+
+    // Clean shutdown first (lets claude reap its own children), then ensure it.
+    let _ = writer.write_all(b"/exit\r");
+    let _ = writer.flush();
+    std::thread::sleep(Duration::from_millis(300));
+    let _ = child.kill();
+    let _ = child.wait();
+    // `master` stays alive until here so the pty isn't torn down early.
+    drop(master);
 }
 
 /// Locate the `claude` binary. Tauri apps launched from Finder/Dock have
@@ -215,6 +326,65 @@ mod tests {
         let mut perms = fs::metadata(path).unwrap().permissions();
         perms.set_mode(0o755);
         fs::set_permissions(path, perms).unwrap();
+    }
+
+    // --- prompt_is_ready (pure) ---
+
+    #[test]
+    fn prompt_is_not_ready_before_any_output() {
+        // No output yet → not ready, even after a quiet stretch.
+        assert!(!prompt_is_ready(
+            false,
+            Duration::from_secs(2),
+            Duration::from_secs(2)
+        ));
+    }
+
+    #[test]
+    fn prompt_is_not_ready_while_output_is_still_flowing() {
+        // Output seen, but the last byte was too recent → REPL still starting.
+        assert!(!prompt_is_ready(
+            true,
+            Duration::from_millis(100),
+            Duration::from_secs(2)
+        ));
+    }
+
+    #[test]
+    fn prompt_is_ready_after_output_then_quiet() {
+        assert!(prompt_is_ready(true, SETTLE_QUIET, Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn prompt_is_ready_at_the_settle_ceiling_regardless_of_output() {
+        // Even if claude never produced output, stop waiting at the cap.
+        assert!(prompt_is_ready(false, Duration::ZERO, SETTLE_CAP));
+    }
+
+    // --- manual end-to-end smoke (real claude + keychain) ---
+    // Gated behind an env var pointing at a profile's cli-config dir, since it
+    // spawns the real binary and makes one trivial API call. Run with:
+    //   AI_PROFILES_PTY_SMOKE="<cli-config dir>" cargo test \
+    //     --manifest-path apps/ai-profiles/src-tauri/Cargo.toml \
+    //     usage::refresh::tests::pty_refresh_smoke -- --nocapture --ignored
+    #[test]
+    #[ignore = "spawns real claude; opt in via AI_PROFILES_PTY_SMOKE"]
+    fn pty_refresh_smoke() {
+        let Ok(dir) = std::env::var("AI_PROFILES_PTY_SMOKE") else {
+            eprintln!("set AI_PROFILES_PTY_SMOKE=<cli-config dir> to run");
+            return;
+        };
+        let dir = std::path::PathBuf::from(dir);
+        let binary = find_claude_binary().expect("claude binary on PATH");
+        let before = crate::usage::credentials::read_access_token(&dir).ok();
+        let started = Instant::now();
+        run_pty_refresh(&binary, &dir, true);
+        let after = crate::usage::credentials::read_access_token(&dir).ok();
+        eprintln!(
+            "pty_refresh_smoke: elapsed={:?} rotated={}",
+            started.elapsed(),
+            before != after
+        );
     }
 
     #[test]

--- a/apps/ai-profiles/src/features/profiles/api/use-profile-usage.ts
+++ b/apps/ai-profiles/src/features/profiles/api/use-profile-usage.ts
@@ -9,6 +9,7 @@ export const refetchIntervalMs = 5 * 60 * 1000
 const knownQuotaErrors: ReadonlyArray<QuotaError> = [
   'no_credentials',
   'unauthorized',
+  'forbidden',
   'needs_login',
   'rate_limited',
   'network',

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -392,6 +392,32 @@ describe('ProfileDetailUsageCard', () => {
     expect(screen.getAllByRole('progressbar')).toHaveLength(3)
   })
 
+  it('names the profile CLI command when sign-in is needed', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: undefined,
+      error: new UsageUnavailableError('needs_login'),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(
+      <ProfileDetailUsageCard app="claude" profileId="p1" cliEnabled={true} cliCommand="claude-personal" />,
+    )
+    expect(screen.getByText(/claude-personal/)).toBeInTheDocument()
+  })
+
+  it('falls back to the stock CLI binary name when no cliCommand is given', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: undefined,
+      error: new UsageUnavailableError('unauthorized'),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(<ProfileDetailUsageCard app="claude" profileId="p1" cliEnabled={true} />)
+    expect(screen.getByText(/run `claude` once/i)).toBeInTheDocument()
+  })
+
   it('shows the Codex no-credentials copy from the app spec', () => {
     ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
       data: undefined,

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { appSpecs } from '@/lib/app-registry'
+import { openCliLogin } from '@/lib/commands'
 
 import { UsageUnavailableError, useProfileUsage } from '../api/use-profile-usage'
 import { ProfileDetailUsageCard } from './profile-detail-usage-card'
@@ -16,6 +17,8 @@ vi.mock('../api/use-profile-usage', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/use-profile-usage')>()
   return { ...actual, useProfileUsage: vi.fn() }
 })
+
+vi.mock('@/lib/commands', () => ({ openCliLogin: vi.fn() }))
 
 function makeUsage(overrides: Partial<ProfileUsage> = {}): ProfileUsage {
   return {
@@ -404,6 +407,21 @@ describe('ProfileDetailUsageCard', () => {
       <ProfileDetailUsageCard app="claude" profileId="p1" cliEnabled={true} cliCommand="claude-personal" />,
     )
     expect(screen.getByText(/claude-personal/)).toBeInTheDocument()
+  })
+
+  it('opens the profile CLI in Terminal when "Refresh sign-in" is clicked', () => {
+    ;(useProfileUsage as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: undefined,
+      error: new UsageUnavailableError('needs_login'),
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+    renderWithQuery(
+      <ProfileDetailUsageCard app="claude" profileId="p1" cliEnabled={true} cliCommand="claude-personal" />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /refresh sign-in/i }))
+    expect(openCliLogin).toHaveBeenCalledWith('p1')
   })
 
   it('falls back to the stock CLI binary name when no cliCommand is given', () => {

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -164,6 +164,9 @@ function quotaErrorShort(quotaError: QuotaError): string {
   if (quotaError === 'unauthorized') {
     return 'token refresh needed'
   }
+  if (quotaError === 'forbidden') {
+    return 'blocked upstream'
+  }
   if (quotaError === 'rate_limited') {
     return 'rate limited'
   }
@@ -188,6 +191,9 @@ function quotaErrorMessage(app: AppId, quotaError: QuotaError): string {
     // Not a real "session expired" — the CLI's short-lived access token rolls
     // over and is refreshed the next time you invoke it.
     return usage?.unauthorized ?? 'Token refresh needed — run the CLI once, then retry.'
+  }
+  if (quotaError === 'forbidden') {
+    return 'Usage request was blocked upstream — usually transient. Try again later.'
   }
   if (quotaError === 'rate_limited') {
     return usage?.rateLimited ?? 'Rate limited. Try again in a few minutes.'

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -16,9 +16,12 @@ type Props = {
   app: AppId
   profileId: string
   cliEnabled: boolean
+  /** Exact CLI command for this profile (`claude-<slug>` wrapper for managed
+   * profiles). Falls back to the stock binary name for the default entry. */
+  cliCommand?: string
 }
 
-export function ProfileDetailUsageCard({ app, profileId, cliEnabled }: Props) {
+export function ProfileDetailUsageCard({ app, profileId, cliEnabled, cliCommand }: Props) {
   // Bumped by the in-boundary Retry button to force the inner query
   // to re-run after a render-time crash. We use it (alongside profileId)
   // as the key on the boundary itself, so switching profiles or hitting
@@ -30,12 +33,12 @@ export function ProfileDetailUsageCard({ app, profileId, cliEnabled }: Props) {
   }
   return (
     <UsageCardErrorBoundary key={`${profileId}:${attempt}`} onRetry={() => setAttempt((value) => value + 1)}>
-      <UsageCardInner app={app} profileId={profileId} />
+      <UsageCardInner app={app} cliCommand={cliCommand ?? appSpecs[app].cliBinary} profileId={profileId} />
     </UsageCardErrorBoundary>
   )
 }
 
-function UsageCardInner({ app, profileId }: { app: AppId; profileId: string }) {
+function UsageCardInner({ app, profileId, cliCommand }: { app: AppId; profileId: string; cliCommand: string }) {
   const { data, error, isLoading, isFetching, dataUpdatedAt, refetch } = useProfileUsage(profileId)
   const errorCode = usageErrorCode(error)
 
@@ -57,7 +60,11 @@ function UsageCardInner({ app, profileId }: { app: AppId; profileId: string }) {
         </div>
       </header>
 
-      {isLoading ? <MetersSkeleton /> : <Body app={app} quota={data?.quota ?? null} errorCode={errorCode} />}
+      {isLoading ? (
+        <MetersSkeleton />
+      ) : (
+        <Body app={app} cliCommand={cliCommand} quota={data?.quota ?? null} errorCode={errorCode} />
+      )}
     </section>
   )
 }
@@ -131,7 +138,17 @@ function usageErrorCode(error: unknown): QuotaError | null {
   return null
 }
 
-function Body({ app, quota, errorCode }: { app: AppId; quota: ProfileUsage['quota']; errorCode: QuotaError | null }) {
+function Body({
+  app,
+  quota,
+  errorCode,
+  cliCommand,
+}: {
+  app: AppId
+  quota: ProfileUsage['quota']
+  errorCode: QuotaError | null
+  cliCommand: string
+}) {
   // Stale-while-revalidate: whenever there's data, show the meters — even if
   // the latest refresh just failed — with a quiet "couldn't refresh" note so
   // the staleness stays honest. The full error message is reserved for when
@@ -147,7 +164,7 @@ function Body({ app, quota, errorCode }: { app: AppId; quota: ProfileUsage['quot
     )
   }
   if (errorCode) {
-    return <p className="font-mono text-mono text-muted-strong">{quotaErrorMessage(app, errorCode)}</p>
+    return <p className="font-mono text-mono text-muted-strong">{quotaErrorMessage(app, errorCode, cliCommand)}</p>
   }
   return <MetersSkeleton />
 }
@@ -179,18 +196,18 @@ function quotaErrorShort(quotaError: QuotaError): string {
 // Resolves the message shown in place of the meters for a given error code.
 // All app-specific copy lives in the registry so a Codex pane never names
 // Anthropic (and vice versa); unknown stays neutral.
-function quotaErrorMessage(app: AppId, quotaError: QuotaError): string {
+function quotaErrorMessage(app: AppId, quotaError: QuotaError, cliCommand: string): string {
   const usage = appSpecs[app].usage
   if (quotaError === 'no_credentials') {
     return usage?.noCredentials ?? 'Sign in once with this profile to see usage.'
   }
   if (quotaError === 'needs_login') {
-    return 'Session expired — sign in to this profile again to see usage.'
+    return `Session expired — run \`${cliCommand}\` and sign in to this profile again.`
   }
   if (quotaError === 'unauthorized') {
     // Not a real "session expired" — the CLI's short-lived access token rolls
-    // over and is refreshed the next time you invoke it.
-    return usage?.unauthorized ?? 'Token refresh needed — run the CLI once, then retry.'
+    // over and is refreshed the next time you invoke it interactively.
+    return `Token refresh needed — run \`${cliCommand}\` once, then retry.`
   }
   if (quotaError === 'forbidden') {
     return 'Usage request was blocked upstream — usually transient. Try again later.'

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail-usage-card.tsx
@@ -9,6 +9,7 @@ import { RefreshCw } from 'lucide-react'
 
 import { TooltipBubble } from '@/design'
 import { appSpecs } from '@/lib/app-registry'
+import { openCliLogin } from '@/lib/commands'
 
 import { refetchIntervalMs, UsageUnavailableError, useProfileUsage } from '../api/use-profile-usage'
 
@@ -63,7 +64,13 @@ function UsageCardInner({ app, profileId, cliCommand }: { app: AppId; profileId:
       {isLoading ? (
         <MetersSkeleton />
       ) : (
-        <Body app={app} cliCommand={cliCommand} quota={data?.quota ?? null} errorCode={errorCode} />
+        <Body
+          app={app}
+          cliCommand={cliCommand}
+          errorCode={errorCode}
+          profileId={profileId}
+          quota={data?.quota ?? null}
+        />
       )}
     </section>
   )
@@ -143,11 +150,13 @@ function Body({
   quota,
   errorCode,
   cliCommand,
+  profileId,
 }: {
   app: AppId
   quota: ProfileUsage['quota']
   errorCode: QuotaError | null
   cliCommand: string
+  profileId: string
 }) {
   // Stale-while-revalidate: whenever there's data, show the meters — even if
   // the latest refresh just failed — with a quiet "couldn't refresh" note so
@@ -160,13 +169,39 @@ function Body({
         {errorCode ? (
           <p className="font-mono text-mono text-muted-strong">Couldn't refresh — {quotaErrorShort(errorCode)}.</p>
         ) : null}
+        {canRelogin(errorCode) ? <ReloginButton profileId={profileId} /> : null}
       </div>
     )
   }
   if (errorCode) {
-    return <p className="font-mono text-mono text-muted-strong">{quotaErrorMessage(app, errorCode, cliCommand)}</p>
+    return (
+      <div className="flex flex-col gap-2">
+        <p className="font-mono text-mono text-muted-strong">{quotaErrorMessage(app, errorCode, cliCommand)}</p>
+        {canRelogin(errorCode) ? <ReloginButton profileId={profileId} /> : null}
+      </div>
+    )
   }
   return <MetersSkeleton />
+}
+
+// A failed token refresh and an expired session both recover the same way:
+// run the profile's CLI interactively once. The button opens it in Terminal.
+function canRelogin(errorCode: QuotaError | null): boolean {
+  return errorCode === 'needs_login' || errorCode === 'unauthorized'
+}
+
+function ReloginButton({ profileId }: { profileId: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void openCliLogin(profileId)
+      }}
+      className="cursor-pointer self-start font-mono text-mono text-muted-strong underline hover:text-fg"
+    >
+      Refresh sign-in
+    </button>
+  )
 }
 
 // Terse reason appended to the "Couldn't refresh — …" note shown beside stale

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail.tsx
@@ -40,7 +40,12 @@ export function ProfileDetail({ profile, onEdit, onDelete }: Props) {
         onEdit={onEdit}
       />
 
-      <ProfileDetailUsageCard app={profile.app} profileId={profile.id} cliEnabled={profile.surfaces.cli} />
+      <ProfileDetailUsageCard
+        app={profile.app}
+        cliCommand={wrapperCommand(profile.app, profile.slug)}
+        cliEnabled={profile.surfaces.cli}
+        profileId={profile.id}
+      />
 
       <div className="mb-6 grid grid-cols-1 gap-3.5 lg:grid-cols-2">
         <Suspense key={profile.id} fallback={<ManagedSurfaceCardsFallback profile={profile} />}>

--- a/apps/ai-profiles/src/lib/commands.ts
+++ b/apps/ai-profiles/src/lib/commands.ts
@@ -132,6 +132,10 @@ export function openExternalUrl(url: string): Promise<void> {
   return invoke('open_external_url', { url })
 }
 
+export function openCliLogin(id: string): Promise<void> {
+  return invoke('open_cli_login', { id })
+}
+
 export function getProfileUsage(profileId: string): Promise<ProfileUsage> {
   return invoke<ProfileUsage>('get_profile_usage', { profileId })
 }

--- a/apps/ai-profiles/src/lib/query/focus.test.ts
+++ b/apps/ai-profiles/src/lib/query/focus.test.ts
@@ -1,0 +1,49 @@
+import { focusManager } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { syncQueryFocusWithWindow } from './focus'
+
+type FocusHandler = (event: { payload: boolean }) => void
+
+const handlers: Array<FocusHandler> = []
+const isFocusedMock = vi.fn()
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    isFocused: isFocusedMock,
+    onFocusChanged: (handler: FocusHandler) => {
+      handlers.push(handler)
+      return Promise.resolve(() => {})
+    },
+  }),
+}))
+
+afterEach(() => {
+  handlers.length = 0
+  focusManager.setFocused(undefined)
+  vi.clearAllMocks()
+})
+
+describe('syncQueryFocusWithWindow', () => {
+  it('seeds focusManager from the current window focus', async () => {
+    isFocusedMock.mockResolvedValue(false)
+    await syncQueryFocusWithWindow()
+    expect(focusManager.isFocused()).toBe(false)
+  })
+
+  it('follows subsequent focus-change events', async () => {
+    isFocusedMock.mockResolvedValue(true)
+    await syncQueryFocusWithWindow()
+    expect(focusManager.isFocused()).toBe(true)
+
+    for (const handler of handlers) {
+      handler({ payload: false })
+    }
+    expect(focusManager.isFocused()).toBe(false)
+
+    for (const handler of handlers) {
+      handler({ payload: true })
+    }
+    expect(focusManager.isFocused()).toBe(true)
+  })
+})

--- a/apps/ai-profiles/src/lib/query/focus.ts
+++ b/apps/ai-profiles/src/lib/query/focus.ts
@@ -1,0 +1,23 @@
+import { focusManager } from '@tanstack/react-query'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+/**
+ * Drives TanStack Query's focusManager from real Tauri window focus.
+ *
+ * The webview's default visibility heuristics report "focused" almost
+ * always, so interval refetches (usage polling) run 24/7 — including
+ * overnight, where an unauthorized response on an unattended poll used to
+ * mark profile credentials dead with nobody around. With focusManager
+ * driven by the actual window state, refetchInterval pauses while the
+ * window is unfocused (refetchIntervalInBackground defaults to false) and
+ * refetchOnWindowFocus fetches fresh data the moment the user returns.
+ *
+ * Returns the Tauri unlisten function.
+ */
+export async function syncQueryFocusWithWindow(): Promise<() => void> {
+  const appWindow = getCurrentWindow()
+  focusManager.setFocused(await appWindow.isFocused())
+  return appWindow.onFocusChanged((event) => {
+    focusManager.setFocused(event.payload)
+  })
+}

--- a/apps/ai-profiles/src/lib/types.ts
+++ b/apps/ai-profiles/src/lib/types.ts
@@ -164,7 +164,14 @@ export type QuotaUsage = {
   secondaryExtra: UsageWindow | null
 }
 
-export type QuotaError = 'no_credentials' | 'unauthorized' | 'needs_login' | 'rate_limited' | 'network' | 'unknown'
+export type QuotaError =
+  | 'no_credentials'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'needs_login'
+  | 'rate_limited'
+  | 'network'
+  | 'unknown'
 
 export type ProfileUsage = {
   quota: QuotaUsage | null

--- a/apps/ai-profiles/src/main.tsx
+++ b/apps/ai-profiles/src/main.tsx
@@ -5,11 +5,15 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 
 import { ThemeProvider, ToastProvider } from '@/design'
+import { syncQueryFocusWithWindow } from '@/lib/query/focus'
 import { QueryProvider } from '@/lib/query/provider'
 
 import App from './app'
 
 import './index.css'
+
+// Pause usage polling while the window is unfocused (see focus.ts).
+void syncQueryFocusWithWindow()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Problem

Managed Claude profiles needed a full \`/login\` roughly daily, while the stock \`~/.claude\` install never did. Opening the app often showed a misleading "auth failed" that a manual \`claude-personal\` run would clear.

Investigation (keychain timestamps, \`.claude.json\` backups, live repro — see \`plans/19\`):

- Anthropic access tokens live ~8h; refresh tokens are **single-use**. The server also sometimes rejects a token ~6h in, before local expiry (anthropics/claude-code#54443).
- The old auto-refresh spawned \`claude\` with **null stdin**, which claude treats as \`--print\` mode — it exited before doing any auth, so it **never actually refreshed** on any installed version (2.1.169–2.1.177). Every 401 therefore ended in a false "session expired."
- 403s (edge/WAF blocks) were conflated with 401s and triggered the same churn.
- Polling ran 24/7, including overnight, hammering the endpoint with stale tokens.

## Changes

1. **403 → its own \`forbidden\` state** — transient upstream blocks no longer masquerade as auth failures or trigger a refresh.
2. **Focus-gated polling** — Tauri window focus drives TanStack Query's \`focusManager\`, so interval refetches pause while the app is unfocused and fetch fresh on return.
3. **Exact CLI command in the copy** — "run \`claude-personal\` once, then retry" instead of a vague message.
4. **One-click "Refresh sign-in"** — a new \`open_cli_login\` command opens the profile's CLI (\`claude-<slug>\`, resolved server-side) in Terminal; the card shows it on \`needs_login\`/\`unauthorized\`.
5. **Working headless refresh** — the refresher now runs \`claude\` under a real pty (\`portable-pty\`, so we own the pid → clean kill, no orphans), waits for the REPL, sends a trivial prompt to trigger claude's own refresh+persist, and verifies via the rotated keychain token. On failure it falls back to (4)'s button.

Net (Hybrid): open app → cached usage shown → background refetch → on a rejected token, auto-refresh silently → only if that fails, one click to re-login.

## Verification

- \`cargo test\` (219), \`cargo clippy -D warnings\`, \`cargo fmt --check\`
- \`vitest\` (236 across 40 files), \`pnpm typecheck\`, biome
- Live: pty refresh validated end-to-end in a dev build (card sat in "refreshing", then showed correct usage with no manual step); pty mechanics smoke-tested (clean bounded exit, zero orphaned processes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)