### PR TITLE
Fix ChatGPT desktop profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-profiles
 
-> Run multiple Claude and Codex accounts on one Mac — the desktop app and the CLI, side by side. Free and open-source.
+> Run multiple Claude and OpenAI accounts on one Mac — Claude Desktop, ChatGPT Desktop, and their CLIs side by side. Free and open-source.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="apps/landing/public/screenshot-dark.png">
@@ -33,13 +33,13 @@ The `.dmg` lands in `apps/ai-profiles/src-tauri/target/release/bundle/dmg/`. mac
 | App | Desktop launcher | CLI wrapper | Auth isolation |
 |-----|-----------------|-------------|----------------|
 | **Claude** (Desktop + Claude Code CLI) | `Claude (<Name>).app` | `claude-<slug>` (sets `CLAUDE_CONFIG_DIR`) | macOS Keychain entry derived from config dir |
-| **Codex** (Desktop + Codex CLI) | `Codex (<Name>).app` | `codex-<slug>` (sets `CODEX_HOME`) | plain `auth.json` inside profile's `CODEX_HOME` — isolation is automatic |
+| **OpenAI** (ChatGPT Desktop + Codex CLI) | `ChatGPT (<Name>).app` | `codex-<slug>` (sets `CODEX_HOME`) | plain `auth.json` inside profile's `CODEX_HOME` — isolation is automatic |
 
 ## Using ai-profiles
 
 Create a profile from the sidebar — choose an app (Claude or Codex), give it a name, pick a colour, and choose which surfaces you want (desktop app, CLI, or both). The app generates everything you need on the spot:
 
-- **Desktop app.** A `Claude (<Name>).app` or `Codex (<Name>).app` launcher lands in `/Applications`. Double-click to open the app with that profile's account, history, and settings. Spotlight, Launchpad, Finder, and ⌘-Tab all see it as its own app, tinted with the profile colour.
+- **Desktop app.** A `Claude (<Name>).app` or `ChatGPT (<Name>).app` launcher lands in `/Applications`. Double-click to open the app with that profile's account, history, and settings. Spotlight, Launchpad, Finder, and ⌘-Tab all see it as its own app, tinted with the profile colour.
 - **CLI.** A `claude-<slug>` or `codex-<slug>` command appears on your `PATH`. Run it in any terminal to start the CLI with that profile's config and login. Each profile keeps its own session and credentials.
 
 Switch profiles from the sidebar, with ⌘1..⌘9 to jump to a slot, ⌘F to filter the list, or ⌘K to open the command palette. ⌘N creates a new profile, ⌘, opens Settings.
@@ -63,7 +63,7 @@ Each profile's detail page shows that profile's current quota utilization alongs
 **Creating your first profile when you already have Claude or Codex installed.** Clicking "+ New profile" opens a fork dialog with two paths:
 
 - **Just add a new profile, keep existing install as-is** (default — press Enter). Leaves your existing install untouched. `claude` or `codex` keeps working with your current account. The new profile is fully separate and accessed via `claude-<slug>` or `codex-<slug>`.
-- **Migrate existing install into a profile.** Adopts your existing `~/.claude` (and `~/Library/Application Support/Claude` if Claude Desktop is installed), or `~/.codex` (and `~/Library/Application Support/Codex` if Codex Desktop is installed), as your first profile. See "What migrate does" below.
+- **Migrate existing install into a profile.** Adopts your existing `~/.claude` (and `~/Library/Application Support/Claude` if Claude Desktop is installed), or `~/.codex` (and `~/Library/Application Support/Codex` if ChatGPT Desktop is installed), as your first profile. The OpenAI support directory keeps its legacy `Codex` name after the desktop-app merge. See "What migrate does" below.
 
 ### What migrate does
 
@@ -71,7 +71,7 @@ Three steps, in order:
 
 1. **Copies** your existing data into the new profile dir under `~/Library/Application Support/ai-profiles/profiles/<id>/`.
 2. **Moves** the originals (`~/.claude` and/or `~/Library/Application Support/Claude` for Claude; `~/.codex` and/or `~/Library/Application Support/Codex` for Codex) into a timestamped backup dir under `~/Library/Application Support/ai-profiles/migration-backup-<timestamp>/`.
-3. **Generates** the per-profile launcher (`Claude (<Name>).app` or `Codex (<Name>).app`) and CLI wrapper (`claude-<slug>` or `codex-<slug>` in `~/.local/bin`).
+3. **Generates** the per-profile launcher (`Claude (<Name>).app` or `ChatGPT (<Name>).app`) and CLI wrapper (`claude-<slug>` or `codex-<slug>` in `~/.local/bin`).
 
 ### After migrating
 

--- a/apps/ai-profiles/src-tauri/Cargo.lock
+++ b/apps/ai-profiles/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ai-profiles"
-version = "0.6.0"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/apps/ai-profiles/src-tauri/src/app_kind.rs
+++ b/apps/ai-profiles/src-tauri/src/app_kind.rs
@@ -27,6 +27,9 @@ pub enum AppKind {
 pub struct AppSpec {
     /// Human-facing product name, e.g. `"Claude"`.
     pub display_name: &'static str,
+    /// Human-facing CLI product name, e.g. `"Codex"` when the desktop app is
+    /// branded as ChatGPT but the command-line product remains Codex.
+    pub cli_display_name: &'static str,
     /// Name passed to `open -a <name>`, e.g. `"Claude"`.
     pub gui_app_name: &'static str,
     /// Stock bundle file name under `/Applications`, e.g. `"Claude.app"`.
@@ -39,6 +42,8 @@ pub struct AppSpec {
     pub gui_macos_exec: &'static str,
     /// Prefix for generated launcher bundles: `"<prefix> (<name>).app"`.
     pub launcher_prefix: &'static str,
+    /// Old launcher bundle prefixes that this app used to generate.
+    pub legacy_launcher_prefixes: &'static [&'static str],
     /// Real CLI binary the wrapper execs, e.g. `"claude"`.
     pub cli_binary: &'static str,
     /// Prefix for generated CLI wrappers: `"<prefix>-<slug>"`.
@@ -64,11 +69,13 @@ pub struct AppSpec {
 
 pub const CLAUDE: AppSpec = AppSpec {
     display_name: "Claude",
+    cli_display_name: "Claude",
     gui_app_name: "Claude",
     gui_bundle_name: "Claude.app",
     gui_support_dir_name: "Claude",
     gui_macos_exec: "Claude",
     launcher_prefix: "Claude",
+    legacy_launcher_prefixes: &[],
     cli_binary: "claude",
     cli_wrapper_prefix: "claude",
     cli_config_env: "CLAUDE_CONFIG_DIR",
@@ -78,12 +85,14 @@ pub const CLAUDE: AppSpec = AppSpec {
 };
 
 pub const CODEX: AppSpec = AppSpec {
-    display_name: "Codex",
-    gui_app_name: "Codex",
-    gui_bundle_name: "Codex.app",
+    display_name: "ChatGPT",
+    cli_display_name: "Codex",
+    gui_app_name: "ChatGPT",
+    gui_bundle_name: "ChatGPT.app",
     gui_support_dir_name: "Codex",
-    gui_macos_exec: "Codex",
-    launcher_prefix: "Codex",
+    gui_macos_exec: "ChatGPT",
+    launcher_prefix: "ChatGPT",
+    legacy_launcher_prefixes: &["Codex"],
     cli_binary: "codex",
     cli_wrapper_prefix: "codex",
     cli_config_env: "CODEX_HOME",
@@ -150,7 +159,13 @@ mod tests {
     #[test]
     fn codex_spec_exposes_codex_surface() {
         let codex = spec(AppKind::Codex);
-        assert_eq!(codex.gui_bundle_name, "Codex.app");
+        assert_eq!(codex.display_name, "ChatGPT");
+        assert_eq!(codex.cli_display_name, "Codex");
+        assert_eq!(codex.gui_app_name, "ChatGPT");
+        assert_eq!(codex.gui_bundle_name, "ChatGPT.app");
+        assert_eq!(codex.gui_macos_exec, "ChatGPT");
+        assert_eq!(codex.launcher_prefix, "ChatGPT");
+        assert_eq!(codex.legacy_launcher_prefixes, &["Codex"]);
         assert_eq!(codex.cli_binary, "codex");
         assert_eq!(codex.cli_config_env, "CODEX_HOME");
         assert_eq!(codex.cli_stock_config_dir_name, ".codex");

--- a/apps/ai-profiles/src-tauri/src/commands.rs
+++ b/apps/ai-profiles/src-tauri/src/commands.rs
@@ -133,6 +133,9 @@ pub fn open_profile_in_app(id: String) -> AppResult<Profile> {
     let data_dir = profile_data_dir(&id)?.join("gui-data");
     let spec = profile.app.spec();
     let app_path = gui_launcher_path(&profile.name, spec);
+    if !app_path.is_dir() {
+        crate::launchers::gui::generate(profile, env!("CARGO_PKG_VERSION"))?;
+    }
     crate::launch::focus_or_launch(&data_dir.display().to_string(), spec, || {
         let status = Command::new("open")
             .arg(&app_path)
@@ -340,7 +343,7 @@ pub fn import_existing_install(app: AppKind, input: ImportExistingInput) -> AppR
     if input.include_cli && existing.cli_path.is_none() {
         return Err(AppError::NotFound(format!(
             "no existing {} CLI install found",
-            app_spec.display_name
+            app_spec.cli_display_name
         )));
     }
 

--- a/apps/ai-profiles/src-tauri/src/deps.rs
+++ b/apps/ai-profiles/src-tauri/src/deps.rs
@@ -1,5 +1,5 @@
 //! Detect external dependencies the app relies on: Claude Desktop, the
-//! Claude Code CLI, Codex Desktop, the Codex CLI, and whether
+//! Claude Code CLI, ChatGPT Desktop, the Codex CLI, and whether
 //! `~/.local/bin` is on the user's interactive shell PATH.
 
 use std::collections::HashMap;

--- a/apps/ai-profiles/src-tauri/src/launch.rs
+++ b/apps/ai-profiles/src-tauri/src/launch.rs
@@ -205,10 +205,13 @@ mod tests {
     fn matches_per_app_exec_name_only() {
         let codex_dir = "/Users/me/Library/Application Support/Codex";
         let codex_ps = format!(
-            "  77001 /Applications/Codex.app/Contents/MacOS/Codex --user-data-dir={codex_dir}\n"
+            "  77001 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --user-data-dir={codex_dir}\n"
         );
-        // The Codex exec matches under "Codex" but is invisible under "Claude".
-        assert_eq!(find_running_pid(&codex_ps, codex_dir, "Codex"), Some(77001));
+        // The ChatGPT exec matches under "ChatGPT" but is invisible under "Claude".
+        assert_eq!(
+            find_running_pid(&codex_ps, codex_dir, "ChatGPT"),
+            Some(77001)
+        );
         assert_eq!(find_running_pid(&codex_ps, codex_dir, "Claude"), None);
     }
 }

--- a/apps/ai-profiles/src-tauri/src/launchers/gui.rs
+++ b/apps/ai-profiles/src-tauri/src/launchers/gui.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use crate::app_kind::AppSpec;
 use crate::error::{AppError, AppResult};
 use crate::launchers::{icons, plist, script};
-use crate::paths::gui_launcher_path;
+use crate::paths::{gui_launcher_path, legacy_gui_launcher_paths};
 use crate::profiles::Profile;
 
 /// Build the .app bundle for `profile` at `/Applications/<App> (<Name>).app/`.
@@ -45,6 +45,15 @@ pub fn generate(profile: &Profile, version: &str) -> AppResult<PathBuf> {
     let icns_bytes = icons::render_icns(&profile.color)?;
     fs::write(resources.join("AppIcon.icns"), icns_bytes)?;
 
+    // The desktop Codex app was renamed to ChatGPT. Once the replacement is
+    // complete, remove any launcher generated under the old `Codex (Name)`
+    // prefix. This is deliberately best-effort: `remove_one` refuses bundles
+    // without our identifier, and an unrelated app at that legacy path must
+    // never prevent the new launcher from being created.
+    for legacy_bundle in legacy_gui_launcher_paths(&profile.name, spec) {
+        let _ = remove_one(&legacy_bundle);
+    }
+
     Ok(bundle)
 }
 
@@ -52,7 +61,14 @@ pub fn generate(profile: &Profile, version: &str) -> AppResult<PathBuf> {
 /// exists and looks like one we generated (sanity check on the Info.plist
 /// contents). No-ops if the bundle doesn't exist.
 pub fn remove(name: &str, spec: &AppSpec) -> AppResult<()> {
-    let bundle = gui_launcher_path(name, spec);
+    remove_one(&gui_launcher_path(name, spec))?;
+    for bundle in legacy_gui_launcher_paths(name, spec) {
+        remove_one(&bundle)?;
+    }
+    Ok(())
+}
+
+fn remove_one(bundle: &PathBuf) -> AppResult<()> {
     if !bundle.exists() {
         return Ok(());
     }
@@ -67,7 +83,7 @@ pub fn remove(name: &str, spec: &AppSpec) -> AppResult<()> {
             )));
         }
     }
-    fs::remove_dir_all(&bundle)?;
+    fs::remove_dir_all(bundle)?;
     Ok(())
 }
 

--- a/apps/ai-profiles/src-tauri/src/launchers/plist.rs
+++ b/apps/ai-profiles/src-tauri/src/launchers/plist.rs
@@ -101,7 +101,7 @@ mod tests {
         let mut profile = fixture("Work");
         profile.app = crate::app_kind::AppKind::Codex;
         let xml = String::from_utf8(info_plist(&profile, "0.1.0").unwrap()).unwrap();
-        assert!(xml.contains("<string>Codex (Work)</string>"));
+        assert!(xml.contains("<string>ChatGPT (Work)</string>"));
         assert!(xml.contains("app.ai-profiles.codex.profile."));
     }
 

--- a/apps/ai-profiles/src-tauri/src/launchers/script.rs
+++ b/apps/ai-profiles/src-tauri/src/launchers/script.rs
@@ -41,7 +41,7 @@ mod tests {
         assert!(launcher_script("abc", &CLAUDE)
             .contains(r#"exec open -n -a "Claude" --args --user-data-dir="$DATA_DIR""#));
         assert!(launcher_script("abc", &CODEX)
-            .contains(r#"exec open -n -a "Codex" --args --user-data-dir="$DATA_DIR""#));
+            .contains(r#"exec open -n -a "ChatGPT" --args --user-data-dir="$DATA_DIR""#));
     }
 
     #[test]

--- a/apps/ai-profiles/src-tauri/src/paths.rs
+++ b/apps/ai-profiles/src-tauri/src/paths.rs
@@ -66,7 +66,18 @@ pub fn applications_dir() -> PathBuf {
 }
 
 pub fn gui_launcher_path(name: &str, spec: &AppSpec) -> PathBuf {
-    applications_dir().join(format!("{} ({name}).app", spec.launcher_prefix))
+    gui_launcher_path_for_prefix(name, spec.launcher_prefix)
+}
+
+fn gui_launcher_path_for_prefix(name: &str, prefix: &str) -> PathBuf {
+    applications_dir().join(format!("{prefix} ({name}).app"))
+}
+
+pub fn legacy_gui_launcher_paths(name: &str, spec: &AppSpec) -> Vec<PathBuf> {
+    spec.legacy_launcher_prefixes
+        .iter()
+        .map(|prefix| gui_launcher_path_for_prefix(name, prefix))
+        .collect()
 }
 
 /// Path to the stock (unmanaged) desktop application bundle. This is the app
@@ -148,7 +159,16 @@ mod tests {
         );
         assert_eq!(
             gui_launcher_path("Personal", &CODEX),
-            PathBuf::from("/Applications/Codex (Personal).app")
+            PathBuf::from("/Applications/ChatGPT (Personal).app")
+        );
+    }
+
+    #[test]
+    fn legacy_gui_launcher_paths_use_legacy_prefixes() {
+        assert!(legacy_gui_launcher_paths("Personal", &CLAUDE).is_empty());
+        assert_eq!(
+            legacy_gui_launcher_paths("Personal", &CODEX),
+            vec![PathBuf::from("/Applications/Codex (Personal).app")]
         );
     }
 
@@ -160,7 +180,7 @@ mod tests {
         );
         assert_eq!(
             gui_app_bundle(&CODEX),
-            PathBuf::from("/Applications/Codex.app")
+            PathBuf::from("/Applications/ChatGPT.app")
         );
     }
 

--- a/apps/ai-profiles/src/features/about/components/about-dialog.tsx
+++ b/apps/ai-profiles/src/features/about/components/about-dialog.tsx
@@ -75,8 +75,8 @@ export function AboutDialog({ open, onClose }: Props) {
         </Field>
       </dl>
       <p className="mt-5 border-t border-border-soft pt-4 text-[11.5px] text-muted-strong">
-        Not affiliated with Anthropic or OpenAI. Claude and Claude.app are trademarks of Anthropic, PBC. Codex and
-        ChatGPT are trademarks of OpenAI.
+        Not affiliated with Anthropic or OpenAI. Claude and Claude.app are trademarks of Anthropic, PBC. ChatGPT and
+        Codex are trademarks of OpenAI.
       </p>
     </Dialog>
   )

--- a/apps/ai-profiles/src/features/command-palette/components/command-palette.test.tsx
+++ b/apps/ai-profiles/src/features/command-palette/components/command-palette.test.tsx
@@ -91,12 +91,12 @@ describe('CommandPalette', () => {
   it('renders a per-app "Detect and import" row for each importable app', () => {
     setup({ entries: [], importableApps: ['claude', 'codex'] })
     expect(screen.getByText('Detect and import Claude…')).toBeInTheDocument()
-    expect(screen.getByText('Detect and import Codex…')).toBeInTheDocument()
+    expect(screen.getByText('Detect and import ChatGPT…')).toBeInTheDocument()
   })
 
   it('fires onImport with the app when an import row is selected', async () => {
     const { onImport, user } = setup({ entries: [], importableApps: ['codex'] })
-    await user.click(screen.getByText('Detect and import Codex…'))
+    await user.click(screen.getByText('Detect and import ChatGPT…'))
     expect(onImport).toHaveBeenCalledWith('codex')
   })
 

--- a/apps/ai-profiles/src/features/migration/api/use-migration.test.ts
+++ b/apps/ai-profiles/src/features/migration/api/use-migration.test.ts
@@ -86,7 +86,7 @@ describe('importableAppsFrom', () => {
   }
 
   it('lists apps with a detected gui or cli install, claude before codex', () => {
-    const apps = importableAppsFrom(byApp(existing({ cliPath: '/x/.claude' }), existing({ guiPath: '/A/Codex.app' })))
+    const apps = importableAppsFrom(byApp(existing({ cliPath: '/x/.claude' }), existing({ guiPath: '/A/ChatGPT.app' })))
     expect(apps).toEqual(['claude', 'codex'])
   })
 

--- a/apps/ai-profiles/src/features/migration/components/migration-dialog.tsx
+++ b/apps/ai-profiles/src/features/migration/components/migration-dialog.tsx
@@ -100,7 +100,11 @@ export function MigrationDialog({ open, app, existing, onClose, onImport }: Prop
                 />
               ) : null}
               {existing.cliPath ? (
-                <DetectedRow label={`${spec.displayName} CLI`} path={existing.cliPath} sizeBytes={sizes.cliSizeBytes} />
+                <DetectedRow
+                  label={`${spec.cliDisplayName} CLI`}
+                  path={existing.cliPath}
+                  sizeBytes={sizes.cliSizeBytes}
+                />
               ) : null}
             </ul>
           </section>
@@ -166,7 +170,7 @@ export function MigrationDialog({ open, app, existing, onClose, onImport }: Prop
                     onChange={(event) => setIncludeCli(event.target.checked)}
                     className="h-3.5 w-3.5 cursor-pointer accent-orange"
                   />
-                  {spec.displayName} CLI config
+                  {spec.cliDisplayName} CLI config
                 </label>
               ) : null}
             </div>
@@ -228,7 +232,7 @@ function WhatWillHappenCard({ app }: { app: AppId }) {
           <code className="font-mono text-mono">{spec.cliBinary}</code> will start a fresh install dir.
         </li>
         <li>
-          <strong className="text-ink">{spec.displayName} CLI:</strong> you'll need to log in once.{' '}
+          <strong className="text-ink">{spec.cliDisplayName} CLI:</strong> you'll need to log in once.{' '}
           {app === 'codex' ? (
             <>
               Credentials live in <code className="font-mono text-mono">auth.json</code> under{' '}

--- a/apps/ai-profiles/src/features/onboarding/components/welcome-dialog.test.tsx
+++ b/apps/ai-profiles/src/features/onboarding/components/welcome-dialog.test.tsx
@@ -8,7 +8,7 @@ describe('WelcomeDialog', () => {
   it('renders the welcome copy when open', () => {
     render(<WelcomeDialog open onContinue={vi.fn()} />)
     expect(screen.getByText(/Welcome to ai-profiles/i)).toBeInTheDocument()
-    expect(screen.getByText(/Claude and Codex accounts/i)).toBeInTheDocument()
+    expect(screen.getByText(/Claude and ChatGPT accounts/i)).toBeInTheDocument()
   })
 
   it('calls onContinue when Continue is clicked', async () => {

--- a/apps/ai-profiles/src/features/onboarding/components/welcome-dialog.tsx
+++ b/apps/ai-profiles/src/features/onboarding/components/welcome-dialog.tsx
@@ -10,7 +10,7 @@ export function WelcomeDialog({ open, onContinue }: Props) {
     <Dialog
       open={open}
       title="Welcome to ai-profiles"
-      description="Run multiple isolated Claude and Codex accounts on one Mac — desktop apps and CLIs, side by side."
+      description="Run multiple isolated Claude and ChatGPT accounts on one Mac — desktop apps and CLIs, side by side."
       onClose={onContinue}
       onSubmit={onContinue}
       foot={

--- a/apps/ai-profiles/src/features/profiles/api/use-sidebar-entries.test.ts
+++ b/apps/ai-profiles/src/features/profiles/api/use-sidebar-entries.test.ts
@@ -22,7 +22,7 @@ describe('makeDefaultEntries', () => {
     const entries = makeDefaultEntries(
       byApp(
         existing({ cliPath: '/Users/me/.claude' }),
-        existing({ guiPath: '/Applications/Codex.app', cliPath: '/Users/me/.codex' }),
+        existing({ guiPath: '/Applications/ChatGPT.app', cliPath: '/Users/me/.codex' }),
       ),
     )
     expect(entries.map((entry) => entry.id)).toEqual(['default:claude', 'default:codex'])
@@ -31,7 +31,7 @@ describe('makeDefaultEntries', () => {
   })
 
   it('emits only codex when claude is absent', () => {
-    const entries = makeDefaultEntries(byApp(existing(), existing({ guiPath: '/Applications/Codex.app' })))
+    const entries = makeDefaultEntries(byApp(existing(), existing({ guiPath: '/Applications/ChatGPT.app' })))
     expect(entries.map((entry) => entry.id)).toEqual(['default:codex'])
   })
 

--- a/apps/ai-profiles/src/features/profiles/components/create-profile-dialog.test.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/create-profile-dialog.test.tsx
@@ -266,7 +266,7 @@ describe('CreateProfileDialog — app-type picker behaviour', () => {
       </ToastProvider>,
     )
     // Codex is the only installed app — it is pre-selected
-    const link = screen.getByRole('link', { name: /Codex Desktop/ })
+    const link = screen.getByRole('link', { name: /ChatGPT Desktop/ })
     expect(link).toHaveAttribute('href', appSpecs.codex.gui.installUrl)
   })
 })

--- a/apps/ai-profiles/src/features/profiles/components/delete-profile-dialog.test.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/delete-profile-dialog.test.tsx
@@ -65,7 +65,7 @@ describe('DeleteProfileDialog', () => {
         onConfirm={vi.fn().mockResolvedValue(undefined)}
       />,
     )
-    expect(screen.getByText(/Codex \(Work\).app/)).toBeInTheDocument()
+    expect(screen.getByText(/ChatGPT \(Work\).app/)).toBeInTheDocument()
     expect(screen.getByText(/\.local\/bin\/codex-work/)).toBeInTheDocument()
   })
 })

--- a/apps/ai-profiles/src/features/profiles/components/empty-state-screen.test.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/empty-state-screen.test.tsx
@@ -14,6 +14,14 @@ const allInstalled: Dependencies = {
   localBinOnPath: true,
 }
 
+const onlyChatGptInstalled: Dependencies = {
+  apps: {
+    claude: { guiInstalled: false, cliInstalled: false },
+    codex: { guiInstalled: true, cliInstalled: false },
+  },
+  localBinOnPath: false,
+}
+
 const noneInstalled: Dependencies = {
   apps: {
     claude: { guiInstalled: false, cliInstalled: false },
@@ -30,12 +38,17 @@ describe('EmptyStateScreen', () => {
     expect(onCreate).toHaveBeenCalledTimes(1)
   })
 
-  it('shows the not-detected state and calls onRefresh when neither Claude is installed', async () => {
+  it('shows the not-detected state and calls onRefresh when no supported surface is installed', async () => {
     const onRefresh = vi.fn().mockResolvedValue(undefined)
     render(<EmptyStateScreen dependencies={noneInstalled} onCreate={vi.fn()} onRefresh={onRefresh} />)
     expect(screen.queryByRole('button', { name: /New profile/ })).not.toBeInTheDocument()
     await userEvent.setup().click(screen.getByRole('button', { name: /Check again/ }))
     expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows the first profile when only ChatGPT Desktop is installed', () => {
+    render(<EmptyStateScreen dependencies={onlyChatGptInstalled} onCreate={vi.fn()} onRefresh={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /New profile/ })).toBeInTheDocument()
   })
 
   it('falls back to the create CTA when only one surface is installed', () => {

--- a/apps/ai-profiles/src/features/profiles/components/empty-state-screen.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/empty-state-screen.tsx
@@ -17,20 +17,18 @@ type Props = {
  * Rendered without a sidebar so the screen owns the whole window.
  *
  * Two modes:
- * - Claude detected → "Create your first profile" CTA.
- * - Neither Claude Desktop nor the CLI detected → install hints + a
+ * - Any supported surface detected → "Create your first profile" CTA.
+ * - No Claude or ChatGPT/Codex surface detected → install hints + a
  *   "Check again" button, because the create dialog can't be submitted
  *   without at least one surface.
  */
 export function EmptyStateScreen({ dependencies, onCreate, onRefresh }: Props) {
-  // Gate is intentionally Claude-only for now: the "not detected" screen and
-  // its CTA speak to installing Claude. Making this app-agnostic (show it only
-  // when NO managed app is detected) is a tracked follow-up, not part of the
-  // dual-vendor copy pass.
-  const claudeMissing = !dependencies.apps.claude.guiInstalled && !dependencies.apps.claude.cliInstalled
+  const hasSupportedSurface = Object.values(dependencies.apps).some(
+    ({ guiInstalled, cliInstalled }) => guiInstalled || cliInstalled,
+  )
 
-  if (claudeMissing) {
-    return <ClaudeNotDetected onRefresh={onRefresh} />
+  if (!hasSupportedSurface) {
+    return <AppsNotDetected onRefresh={onRefresh} />
   }
 
   return <NoProfilesYet onCreate={onCreate} />
@@ -55,7 +53,7 @@ function NoProfilesYet({ onCreate }: NoProfilesYetProps) {
         Create your first profile.
       </h1>
       <p className="m-0 mb-5 max-w-[380px] text-[13.5px] leading-[1.55] tracking-[-0.003em] text-muted">
-        Each profile is one isolated Claude or Codex account, with its own Desktop launcher and CLI wrapper. Logins,
+        Each profile is one isolated Claude or ChatGPT account, with its own Desktop launcher and CLI wrapper. Logins,
         history, and chats stay isolated.
       </p>
       <Button
@@ -72,11 +70,11 @@ function NoProfilesYet({ onCreate }: NoProfilesYetProps) {
   )
 }
 
-type ClaudeNotDetectedProps = {
+type AppsNotDetectedProps = {
   onRefresh: () => Promise<void> | void
 }
 
-function ClaudeNotDetected({ onRefresh }: ClaudeNotDetectedProps) {
+function AppsNotDetected({ onRefresh }: AppsNotDetectedProps) {
   const [refreshing, setRefreshing] = useState(false)
 
   async function handleRefresh() {
@@ -95,29 +93,34 @@ function ClaudeNotDetected({ onRefresh }: ClaudeNotDetectedProps) {
     <main className="flex h-full min-h-[600px] flex-1 flex-col items-center justify-center px-10 py-16 text-center">
       <BrandMark />
       <div className="mb-2.5 font-mono text-[10.5px] font-medium uppercase tracking-[0.14em] text-muted-strong">
-        Claude not detected
+        No supported app detected
       </div>
       <h1 className="m-0 mb-3 text-h1 font-bold tracking-[-0.028em] text-ink leading-[1.1]">
-        Install Claude to begin.
+        Install an app to begin.
       </h1>
       <p className="m-0 mb-6 max-w-[420px] text-[13.5px] leading-[1.55] tracking-[-0.003em] text-muted">
-        ai-profiles wraps the Claude and Codex desktop apps and CLIs. Install Claude to get started.
+        ai-profiles supports Claude Desktop, ChatGPT Desktop, Claude Code, and the Codex CLI.
       </p>
       <div className="mb-6 flex w-full max-w-[440px] flex-col gap-2.5 text-left">
         <div className="rounded-lg border border-border bg-white px-3.5 py-3 text-[12.5px] leading-[1.5] text-ink-soft dark:bg-cream-2">
-          <div className="mb-0.5 font-medium text-ink">Claude Desktop</div>
+          <div className="mb-0.5 font-medium text-ink">Desktop apps</div>
           <span className="text-muted">
-            Download from{' '}
+            Download{' '}
             <a className="underline" href="https://claude.ai/download" target="_blank" rel="noreferrer">
-              claude.ai/download
+              Claude
+            </a>{' '}
+            or{' '}
+            <a className="underline" href="https://chatgpt.com/download/" target="_blank" rel="noreferrer">
+              ChatGPT
             </a>
             .
           </span>
         </div>
         <div className="rounded-lg border border-border bg-white px-3.5 py-3 text-[12.5px] leading-[1.5] text-ink-soft dark:bg-cream-2">
-          <div className="mb-0.5 font-medium text-ink">Claude CLI</div>
+          <div className="mb-0.5 font-medium text-ink">Command-line apps</div>
           <span className="text-muted">
-            Run <code className="font-mono text-mono text-ink">npm install -g @anthropic-ai/claude-code</code>.
+            Install <code className="font-mono text-mono text-ink">@anthropic-ai/claude-code</code> or{' '}
+            <code className="font-mono text-mono text-ink">@openai/codex</code> with npm.
           </span>
         </div>
       </div>

--- a/apps/ai-profiles/src/features/profiles/components/profile-detail-surface-card.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-detail-surface-card.tsx
@@ -38,7 +38,7 @@ const surfaceIcon: Record<SurfaceVariant, ReactNode> = {
 
 /**
  * Per-app surface-card copy, sourced from the registry so a Codex profile
- * describes Codex surfaces (Codex.app, the `codex` binary, `CODEX_HOME`,
+ * describes Codex surfaces (ChatGPT.app, the `codex` binary, `CODEX_HOME`,
  * `codex-<slug>`) rather than the Claude defaults.
  */
 function surfaceCopy(app: AppId, variant: SurfaceVariant): { title: string; description: string } {
@@ -50,7 +50,7 @@ function surfaceCopy(app: AppId, variant: SurfaceVariant): { title: string; desc
     }
   }
   return {
-    title: `${spec.displayName} CLI`,
+    title: `${spec.cliDisplayName} CLI`,
     description: `Wraps the ${spec.cliBinary} binary with ${spec.cliConfigEnv} pointed at this profile, exposed as ${spec.cliWrapperPrefix}-{slug}.`,
   }
 }

--- a/apps/ai-profiles/src/features/profiles/components/profile-form-fields.tsx
+++ b/apps/ai-profiles/src/features/profiles/components/profile-form-fields.tsx
@@ -142,7 +142,7 @@ export function ProfileFormFields({
             <p className="pl-7 font-mono text-mono text-muted-strong">
               Install{' '}
               <a className="underline" href={spec?.cli.installUrl} target="_blank" rel="noreferrer">
-                {spec?.displayName}
+                {spec?.cliDisplayName}
               </a>{' '}
               first.
             </p>

--- a/apps/ai-profiles/src/features/settings/components/settings-view.test.tsx
+++ b/apps/ai-profiles/src/features/settings/components/settings-view.test.tsx
@@ -115,7 +115,7 @@ describe('SettingsView', () => {
     renderSettings(<SettingsView onClose={vi.fn()} onOpenMigration={vi.fn()} onOpenAbout={vi.fn()} />)
     await waitFor(() => expect(screen.getByText('Claude Desktop')).toBeInTheDocument())
     expect(screen.getByText('Claude CLI')).toBeInTheDocument()
-    expect(screen.getByText('Codex Desktop')).toBeInTheDocument()
+    expect(screen.getByText('ChatGPT Desktop')).toBeInTheDocument()
     expect(screen.getByText('Codex CLI')).toBeInTheDocument()
     expect(screen.getByText('Shell PATH')).toBeInTheDocument()
   })

--- a/apps/ai-profiles/src/features/settings/components/system-section.tsx
+++ b/apps/ai-profiles/src/features/settings/components/system-section.tsx
@@ -55,7 +55,7 @@ function buildAppRows(dependencies: Dependencies): Array<Row> {
     const deps = dependencies.apps[id]
     return [
       { label: `${spec.displayName} Desktop`, tone: deps.guiInstalled ? 'success' : 'warning', detail: MISSING_DETAIL },
-      { label: `${spec.displayName} CLI`, tone: deps.cliInstalled ? 'success' : 'warning', detail: MISSING_DETAIL },
+      { label: `${spec.cliDisplayName} CLI`, tone: deps.cliInstalled ? 'success' : 'warning', detail: MISSING_DETAIL },
     ]
   })
 }

--- a/apps/ai-profiles/src/lib/app-registry.ts
+++ b/apps/ai-profiles/src/lib/app-registry.ts
@@ -36,6 +36,8 @@ export type AppUsageSpec = {
 export type AppSpec = {
   id: AppId
   displayName: string
+  /** CLI product name when it differs from the desktop brand (ChatGPT/Codex). */
+  cliDisplayName: string
   hasUsage: boolean
   gui: AppSurfaceSpec
   cli: AppSurfaceSpec
@@ -64,6 +66,7 @@ export type AppSpec = {
 const claude: AppSpec = {
   id: 'claude',
   displayName: 'Claude',
+  cliDisplayName: 'Claude',
   hasUsage: true,
   gui: {
     label: 'Desktop App launcher',
@@ -98,12 +101,13 @@ const claude: AppSpec = {
 
 const codex: AppSpec = {
   id: 'codex',
-  displayName: 'Codex',
+  displayName: 'ChatGPT',
+  cliDisplayName: 'Codex',
   hasUsage: true,
   gui: {
     label: 'Desktop App launcher',
-    description: 'Creates /Applications/Codex (Name).app with an isolated user-data directory.',
-    installUrl: 'https://chatgpt.com/codex',
+    description: 'Creates /Applications/ChatGPT (Name).app with an isolated user-data directory.',
+    installUrl: 'https://chatgpt.com/download/',
   },
   cli: {
     label: 'Codex CLI wrapper',
@@ -111,10 +115,10 @@ const codex: AppSpec = {
     installUrl: 'https://www.npmjs.com/package/@openai/codex',
   },
   usage: {
-    noCredentials: 'Sign in to Codex once with this profile to see usage.',
+    noCredentials: 'Sign in to ChatGPT once with this profile to see usage.',
     unauthorized: 'Token refresh needed — run `codex` in a terminal once, then retry.',
     rateLimited: 'Rate limited by OpenAI. Try again in a few minutes.',
-    networkError: "Couldn't read Codex usage — make sure the Codex CLI is installed and signed in.",
+    networkError: "Couldn't read ChatGPT usage — make sure the Codex CLI is installed and signed in.",
     primaryLabel: '5-hour window',
     primaryShortLabel: '5h',
     secondaryLabel: 'Weekly',
@@ -123,7 +127,7 @@ const codex: AppSpec = {
     secondaryExtraShortLabel: null,
   },
   accentVar: '--color-codex',
-  guiBundleName: 'Codex.app',
+  guiBundleName: 'ChatGPT.app',
   cliBinary: 'codex',
   cliWrapperPrefix: 'codex',
   cliConfigEnv: 'CODEX_HOME',

--- a/apps/landing/src/data/faq.ts
+++ b/apps/landing/src/data/faq.ts
@@ -22,7 +22,7 @@ export const faqEntries: ReadonlyArray<FaqEntry> = [
   {
     question: "What does 'migrate' actually do to my data?",
     answer:
-      'Three things, in order: (1) copies the stock app data into the new profile directory under ~/Library/Application Support/ai-profiles/profiles/<id>/ — ~/.claude and ~/Library/Application Support/Claude for a Claude profile, or ~/.codex and ~/Library/Application Support/Codex for a Codex profile; (2) moves the originals into a 7-day backup dir under migration-backup-<timestamp>/; (3) generates the CLI wrapper and launcher (claude-<slug> + Claude (<Name>).app, or codex-<slug> + Codex (<Name>).app). To revert: copy the backup folder contents back to their original locations.',
+      'Three things, in order: (1) copies the stock app data into the new profile directory under ~/Library/Application Support/ai-profiles/profiles/<id>/ — ~/.claude and ~/Library/Application Support/Claude for a Claude profile, or ~/.codex and ~/Library/Application Support/Codex for an OpenAI profile (ChatGPT Desktop retains the Codex support-directory name); (2) moves the originals into a 7-day backup dir under migration-backup-<timestamp>/; (3) generates the CLI wrapper and launcher (claude-<slug> + Claude (<Name>).app, or codex-<slug> + ChatGPT (<Name>).app). To revert: copy the backup folder contents back to their original locations.',
   },
   {
     question: 'Is it affiliated with Anthropic or OpenAI?',


### PR DESCRIPTION
## Summary\n\n- Migrate desktop discovery and isolated launchers from Codex.app to ChatGPT.app.\n- Preserve Codex CLI behavior, CODEX_HOME, and existing support-directory compatibility.\n- Regenerate missing ChatGPT launchers and remove legacy Codex profile launchers.\n- Update UI copy, documentation, and tests for the merged desktop app.\n\n## Root cause\n\nOpenAI merged Codex into ChatGPT Desktop. The previous dependency check only recognized /Applications/Codex.app, so newly created profiles persisted with the desktop surface disabled even when ChatGPT.app was installed.\n\n## Validation\n\n- Rust: 221 passed, 1 ignored\n- App Vitest: 237 passed\n- Landing Vitest: 13 passed\n- TypeScript typecheck, Biome, Clippy, and Vite production build passed\n- Live macOS smoke test confirmed ChatGPT launches with the profile-specific --user-data-dir and reuses the existing isolated instance\n